### PR TITLE
Replacing the type annotation "re.Match" with Match from the typing m…

### DIFF
--- a/nbqa/__main__.py
+++ b/nbqa/__main__.py
@@ -11,7 +11,7 @@ import tempfile
 from pathlib import Path
 from shlex import split
 from textwrap import dedent
-from typing import Dict, Iterator, List, Optional, Set, Tuple
+from typing import Dict, Iterator, List, Match, Optional, Set, Tuple
 
 from nbqa import __version__, replace_source, save_source
 
@@ -218,7 +218,7 @@ def _map_python_line_to_nb_lines(
     """
     pattern = rf"(?<={notebook.name}:)\d+"
 
-    def substitution(match: "re.Match") -> str:
+    def substitution(match: Match[str]) -> str:
         """Replace Python line with corresponding Jupyter notebook cell."""
         return str(cell_mapping[int(match.group())])
 


### PR DESCRIPTION
Replacing the type annotation "re.Match" with type alias `Match` from the `typing` module in python

Reference:
https://docs.python.org/3.6/library/typing.html#typing.Match

Changes to be committed:
	modified:   nbqa/__main__.py