### PR TITLE
Update the checkout and setup-python github actions from v1 to v2.

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -9,12 +9,12 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-python@v1
-    - name: set PY
-      run: echo "::set-env name=PY::$(python -c 'import hashlib, sys;print(hashlib.sha256(sys.version.encode()+sys.executable.encode()).hexdigest())')"
-    - uses: actions/cache@v1
-      with:
-        path: ~/.cache/pre-commit
-        key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
-    - uses: pre-commit/action@v1.1.0
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - name: set PY
+        run: echo "::set-env name=PY::$(python -c 'import hashlib, sys;print(hashlib.sha256(sys.version.encode()+sys.executable.encode()).hexdigest())')"
+      - uses: actions/cache@v2
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
+      - uses: pre-commit/action@v1.1.0

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,10 +11,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
-      - name: set PY
-        run: echo "::set-env name=PY::$(python -c 'import hashlib, sys;print(hashlib.sha256(sys.version.encode()+sys.executable.encode()).hexdigest())')"
-      - uses: actions/cache@v2
-        with:
-          path: ~/.cache/pre-commit
-          key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
-      - uses: pre-commit/action@v1.1.0
+      - uses: pre-commit/action@v2.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,41 +1,43 @@
+default_language_version:
+  # force all unspecified python hooks to run python3
+  python: python3
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.1.0
     hooks:
-    -   id: end-of-file-fixer
-    -   id: requirements-txt-fixer
-    -   id: trailing-whitespace
-    -   id: debug-statements
--   repo: https://github.com/python/black
+      - id: end-of-file-fixer
+      - id: requirements-txt-fixer
+      - id: trailing-whitespace
+      - id: debug-statements
+  - repo: https://github.com/python/black
     rev: 20.8b1
     hooks:
-    -   id: black
-        language_version: python3
--   repo: https://gitlab.com/pycqa/flake8
+      - id: black
+  - repo: https://gitlab.com/pycqa/flake8
     rev: 3.8.3
     hooks:
-    -   id: flake8
--   repo: https://github.com/timothycrosley/isort
+      - id: flake8
+  - repo: https://github.com/timothycrosley/isort
     rev: 5.0.9
     hooks:
-    -   id: isort
--   repo: https://github.com/pre-commit/mirrors-mypy
+      - id: isort
+  - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.782
     hooks:
-    -   id: mypy
--   repo: https://github.com/PyCQA/pydocstyle
+      - id: mypy
+  - repo: https://github.com/PyCQA/pydocstyle
     rev: 5.0.2
     hooks:
-    -   id: pydocstyle
-        exclude: 'docs'
--   repo: https://github.com/econchick/interrogate
+      - id: pydocstyle
+        exclude: "docs"
+  - repo: https://github.com/econchick/interrogate
     rev: 1.2.0
     hooks:
-    -   id: interrogate
+      - id: interrogate
         args: [-v, --fail-under=100]
         exclude: (docs|__init__.py)
--   repo: https://github.com/pre-commit/mirrors-mypy
+  - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.782
     hooks:
-    -   id: mypy
-        exclude: 'docs'
+      - id: mypy
+        exclude: "docs"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,10 +21,6 @@ repos:
     rev: 5.0.9
     hooks:
       - id: isort
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.782
-    hooks:
-      - id: mypy
   - repo: https://github.com/PyCQA/pydocstyle
     rev: 5.0.2
     hooks:


### PR DESCRIPTION
* **checkout@v2** has improved performance over **checkout@v1** github action
* Similarly its recommended to update from **setup-python@v1** to v2
* Made python3 as the version to be used by all the pre-commit hooks globally rather than explicitly mentioning the python version in each of the precommit hooks.

Changes to be committed:
	modified:   .github/workflows/pre-commit.yml
	modified:   .pre-commit-config.yaml