### PR TITLE
DOC Update authors

### DIFF
--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -2,13 +2,10 @@
 Credits
 =======
 
-Development Lead
-----------------
+Authors (in chronological order of first contribution)
+------------------------------------------------------
 
-* Marco Gorelli
-
-Contributors
-------------
-
-- s-weigand
+- MarcoGorelli (Marco Gorelli)
+- s-weigand (Sebastian Weigand)
 - fcatus
+- girip11 (Girish Pasupathy)


### PR DESCRIPTION
If more contributors come by we can make a script, but for now this is fine.

Else, @s-weigand , do you feel like making a PR to have the "all contributors specification" show up, as in your flake8-nb repo?