### PR TITLE
remove extra all-contributors badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,4 @@
 <img src="https://github.com/nbQA-dev/nbQA/raw/master/assets/logo.png" alt="logo" width="400"/>
-<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-4-orange.svg?style=flat-square)](#contributors-)
-<!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 # nbQA
 


### PR DESCRIPTION
There's already one of these at the bottom of the README, we don't need this one, right?