### PR TITLE
Remove pylint config E0401 and make pylint a local pre-commit hook

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,4 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
+      # This is required since pylint is used in pre-commit as a local hook
+      - name: install-pylint
+        run: python -m pip install --upgrade pip pylint
       - uses: pre-commit/action@v2.0.0

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,6 +12,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
       # This is required since pylint is used in pre-commit as a local hook
-      - name: install-pylint
-        run: python -m pip install --upgrade pip pylint
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
       - uses: pre-commit/action@v2.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,8 @@ repos:
         types: [python]
         require_serial: true
         exclude: "docs"
+        args:
+          - "--rcfile=pyproject.toml"
   - repo: https://gitlab.com/pycqa/flake8
     rev: 3.8.3
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,10 +18,14 @@ repos:
     hooks:
       - id: prettier
         exclude: README.md
-  - repo: https://github.com/pycqa/pylint
-    rev: pylint-2.6.0
+  - repo: local
     hooks:
       - id: pylint
+        name: pylint
+        entry: pylint
+        language: system
+        types: [python]
+        require_serial: true
         exclude: "docs"
   - repo: https://gitlab.com/pycqa/flake8
     rev: 3.8.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.interrogate]
-ignore-init-method = true
 fail-under = 100
+ignore-init-method = true
 
 [tool.isort]
 profile = "black"
@@ -10,20 +10,19 @@ source = ["nbqa"]
 
 [tool.coverage.report]
 exclude_lines = [
-    "pragma: nocover",
-    "raise NotImplementedError",
-    "if __name__ == .__main__.:",
-    "if TYPE_CHECKING:",
-    ]
+  "pragma: nocover",
+  "raise NotImplementedError",
+  "if __name__ == .__main__.:",
+  "if TYPE_CHECKING:",
+]
 ignore_errors = true
 omit = [
-    "tests/*",
-    ]
+  "tests/*",
+]
 
 [tool.pylint.messages_control]
-disable =[
-    "C0330",  # to work well with `black`
-    "R0801",  # Unfortunately I do need some duplication, e.g. with imports
-    "W1510",  # I need to run subprocess.run without check because it's OK if it fails
-    "E0401",  # import error: I run pylint in a separate environment so it's OK
-    ]
+disable = [
+  "C0330", # to work well with `black`
+  "R0801", # Unfortunately I do need some duplication, e.g. with imports
+  "W1510", # I need to run subprocess.run without check because it's OK if it fails
+]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,4 +3,5 @@ coverage[toml]
 flake8
 isort>=5.4.2
 mypy
+pylint
 pytest


### PR DESCRIPTION
Addresses the issue [#212](https://github.com/nbQA-dev/nbQA/issues/212)

If this rule **E0401** is removed from the pylint conf, we would get import error. **pytest and other import dependencies** in the source/test files won't be available to the pylint module since this would be run in an isolated environment by the pre-commit.  

To fix this issue we have 2 options.

1. We need to make all our source and test dependencies available to pylint during pre-commit check using the **additional_dependencies** key **.pre-commit-config.yaml** for pylint would look like below. But this rule would keep failing as and when we take dependency on some new other 3rd party package.

```YAML
  - repo: https://github.com/pycqa/pylint
    rev: pylint-2.6.0
    hooks:
      - id: pylint
        exclude: "docs"
        additional_dependencies:
          - "pytest"
```

2. Alternatively, we can make pylint as a local hook as suggested by creator the pre-commit. This is a generic change. We can freely add new dependencies and no need to change the pre-commit config everytime.

> pre-commit runs pylint from an isolated virtualenv. Many of pylint's checks perform dynamic analysis which will fail there. You may find configuring pylint as a local hook more useful.

I tried making pylint as a local hook with **language: system**. This will make the pylint picked up from our virtual environment or some other local environment based on PATH variable. When we develop, usually we have the virtual environment activated, so pre-commit will have not issue finding and running pylint. In github actions, we need to install all the dependencies for pylint to work under system flag before the precommit step is run.

3. Don't enable pylint rule E0401.