### PR TITLE
CLN, TST remove unnecessary checks of diff

### DIFF
--- a/tests/test_flake8_works.py
+++ b/tests/test_flake8_works.py
@@ -9,8 +9,6 @@ import pytest
 from nbqa.__main__ import main
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from _pytest.capture import CaptureFixture
 
 

--- a/tests/test_flake8_works.py
+++ b/tests/test_flake8_works.py
@@ -34,7 +34,6 @@ def test_flake8_works(capsys: "CaptureFixture") -> None:
         os.path.join("tests", "data", "notebook_starting_with_md.ipynb")
     )
 
-    # check diff
     with pytest.raises(SystemExit):
         main(["flake8", path_0, path_1, path_2])
 

--- a/tests/test_flake8_works.py
+++ b/tests/test_flake8_works.py
@@ -1,6 +1,5 @@
 """Check :code:`flake8` works as intended."""
 
-import difflib
 import os
 from textwrap import dedent
 from typing import TYPE_CHECKING
@@ -15,9 +14,7 @@ if TYPE_CHECKING:
     from _pytest.capture import CaptureFixture
 
 
-def test_flake8_works(
-    tmp_notebook_for_testing: "Path", capsys: "CaptureFixture"
-) -> None:
+def test_flake8_works(capsys: "CaptureFixture") -> None:
     """
     Check flake8 works. Shouldn't alter the notebook content.
 
@@ -40,16 +37,8 @@ def test_flake8_works(
     )
 
     # check diff
-    with open(tmp_notebook_for_testing, "r") as handle:
-        before = handle.readlines()
     with pytest.raises(SystemExit):
         main(["flake8", path_0, path_1, path_2])
-
-    with open(tmp_notebook_for_testing, "r") as handle:
-        after = handle.readlines()
-    result = "".join(difflib.unified_diff(before, after))
-    expected = ""
-    assert result == expected
 
     out, err = capsys.readouterr()
     expected_out = dedent(

--- a/tests/test_flake8_works.py
+++ b/tests/test_flake8_works.py
@@ -20,8 +20,6 @@ def test_flake8_works(capsys: "CaptureFixture") -> None:
 
     Parameters
     ----------
-    tmp_notebook_for_testing
-        Temporary copy of :code:`notebook_for_testing.ipynb`.
     capsys
         Pytest fixture to capture stdout and stderr.
     """

--- a/tests/test_mypy_works.py
+++ b/tests/test_mypy_works.py
@@ -1,6 +1,5 @@
 """Check :code:`mypy` works as intended."""
 
-import difflib
 import os
 from textwrap import dedent
 from typing import TYPE_CHECKING
@@ -15,28 +14,17 @@ if TYPE_CHECKING:
     from _pytest.capture import CaptureFixture
 
 
-def test_mypy_works(tmp_notebook_for_testing: "Path", capsys: "CaptureFixture") -> None:
+def test_mypy_works(capsys: "CaptureFixture") -> None:
     """
     Check mypy works. Shouldn't alter the notebook content.
 
     Parameters
     ----------
-    tmp_notebook_for_testing
-        Temporary copy of :code:`notebook_for_testing.ipynb`.
     capsys
         Pytest fixture to capture stdout and stderr.
     """
-    # check diff
-    with open(tmp_notebook_for_testing, "r") as handle:
-        before = handle.readlines()
     with pytest.raises(SystemExit):
         main(["mypy", "--ignore-missing-imports", "--allow-untyped-defs", "tests"])
-
-    with open(tmp_notebook_for_testing, "r") as handle:
-        after = handle.readlines()
-    result = "".join(difflib.unified_diff(before, after))
-    expected = ""
-    assert result == expected
 
     # check out and err
     out, err = capsys.readouterr()

--- a/tests/test_mypy_works.py
+++ b/tests/test_mypy_works.py
@@ -9,8 +9,6 @@ import pytest
 from nbqa.__main__ import main
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from _pytest.capture import CaptureFixture
 
 

--- a/tests/test_setupcfg.py
+++ b/tests/test_setupcfg.py
@@ -1,6 +1,5 @@
 """Check configs from :code:`setup.cfg` are picked up."""
 
-import difflib
 import os
 from pathlib import Path
 from textwrap import dedent
@@ -14,16 +13,12 @@ if TYPE_CHECKING:
     from _pytest.capture import CaptureFixture
 
 
-def test_nbqa_ini_works(
-    tmp_notebook_for_testing: Path, capsys: "CaptureFixture"
-) -> None:
+def test_nbqa_ini_works(capsys: "CaptureFixture") -> None:
     """
     Check setup.cfg config is picked up works.
 
     Parameters
     ----------
-    tmp_notebook_for_testing
-        Temporary copy of :code:`notebook_for_testing.ipynb`.
     capsys
         Pytest fixture to capture stdout and stderr.
     """
@@ -39,19 +34,10 @@ def test_nbqa_ini_works(
             )
         )
 
-    # check diff
-    with open(tmp_notebook_for_testing, "r") as handle:
-        before = handle.readlines()
     with pytest.raises(SystemExit):
         main(["flake8", "tests", "--ignore", "E302"])
 
     Path("setup.cfg").unlink()
-
-    with open(tmp_notebook_for_testing, "r") as handle:
-        after = handle.readlines()
-    result = "".join(difflib.unified_diff(before, after))
-    expected = ""
-    assert result == expected
 
     # check out and err
     out, err = capsys.readouterr()


### PR DESCRIPTION
These are tests which don't even use --nbqa-mutate, so IMO it's OK to simplify them