### PR TITLE
Strip trailing newlines before converting

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -60,6 +60,9 @@ or you can put the following in your :code:`pyproject.toml` file
     [tool.nbqa.mutate]
     black = 1
 
+.. note::
+    If you let :code:`nbQA` mutate your notebook, then trailing newlines will be removed from cells.
+
 Ignore cells
 ~~~~~~~~~~~~
 

--- a/nbqa/__main__.py
+++ b/nbqa/__main__.py
@@ -464,9 +464,7 @@ def _run_on_one_root_dir(
                 cell_mappings[notebook],
                 trailing_semicolons[notebook],
                 temporary_lines[notebook],
-            ) = save_source.main(
-                notebook, temp_python_file, cli_args.command, configs.nbqa_ignore_cells
-            )
+            ) = save_source.main(notebook, temp_python_file, configs.nbqa_ignore_cells)
             _create_blank_init_files(notebook, tmpdirname, project_root)
 
         out, err, output_code, mutated = _run_command(

--- a/nbqa/save_source.py
+++ b/nbqa/save_source.py
@@ -6,7 +6,6 @@ Markdown cells, output, and metadata are ignored.
 
 import json
 import secrets
-from collections import defaultdict
 from itertools import takewhile
 from typing import TYPE_CHECKING, Dict, Iterator, List, Optional, Tuple
 
@@ -14,8 +13,6 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 CODE_SEPARATOR = "# %%"
-BLANK_SPACES = defaultdict(lambda: "\n\n")
-BLANK_SPACES["isort"] = "\n"
 MAGIC = ["%%script", "%%bash"]
 IGNORE_CELL_REPLACEMENT = "# nbqa"
 IGNORE_LINE_REPLACEMENT = "pass  # nbqa"
@@ -67,7 +64,6 @@ def _replace_magics(
 
 def _parse_cell(
     source: List[str],
-    command: str,
     ignore_cells: List[str],
     temporary_lines: Dict[str, str],
 ) -> str:
@@ -78,8 +74,6 @@ def _parse_cell(
     ----------
     source
         Source from notebook cell.
-    command
-        Third-party tool we're running.
     ignore_cells
         Extra cells which nbqa should ignore.
     temporary_lines
@@ -90,7 +84,7 @@ def _parse_cell(
     str
         Parsed cell.
     """
-    parsed_cell = f"{BLANK_SPACES[command]}{CODE_SEPARATOR}\n"
+    parsed_cell = f"\n{CODE_SEPARATOR}\n"
     for new, old in _replace_magics(source, ignore_cells):
         parsed_cell += new
         if old is not None:
@@ -102,7 +96,6 @@ def _parse_cell(
 def main(
     notebook: "Path",
     temp_python_file: "Path",
-    command: str,
     ignore_cells: List[str],
 ) -> Tuple[Dict[int, str], List[int], Dict[str, str]]:
     """
@@ -114,8 +107,6 @@ def main(
         Jupyter Notebook third-party tool is being run against.
     temp_python_file
         Temporary Python file to save converted notebook in.
-    command
-        Third party tool which you're running on your notebook.
     ignore_cells
         Extra cells which nbqa should ignore.
 
@@ -141,7 +132,7 @@ def main(
     for i in cells:
         if i["cell_type"] != "code":
             continue
-        parsed_cell = _parse_cell(i["source"], command, ignore_cells, temporary_lines)
+        parsed_cell = _parse_cell(i["source"], ignore_cells, temporary_lines)
         result.append(parsed_cell)
         split_parsed_cell = parsed_cell.splitlines()
         cell_mapping.update(
@@ -156,6 +147,6 @@ def main(
         cell_number += 1
 
     with open(str(temp_python_file), "w") as handle:
-        handle.write("".join(result)[len(BLANK_SPACES[command]) :])
+        handle.write("".join(result)[len("\n") :])
 
     return cell_mapping, trailing_semicolons, temporary_lines

--- a/nbqa/save_source.py
+++ b/nbqa/save_source.py
@@ -95,7 +95,7 @@ def _parse_cell(
         parsed_cell += new
         if old is not None:
             temporary_lines[new] = old
-    parsed_cell += "\n"
+    parsed_cell = parsed_cell.rstrip("\n") + "\n"
     return parsed_cell
 
 
@@ -156,6 +156,6 @@ def main(
         cell_number += 1
 
     with open(str(temp_python_file), "w") as handle:
-        handle.write("".join(result)[len(BLANK_SPACES[command]) : -len("\n")])
+        handle.write("".join(result)[len(BLANK_SPACES[command]) :])
 
     return cell_mapping, trailing_semicolons, temporary_lines

--- a/tests/data/notebook_with_trailing_semicolon.ipynb
+++ b/tests/data/notebook_with_trailing_semicolon.ipynb
@@ -18,7 +18,7 @@
    "outputs": [],
    "source": [
     "def func(a, b):\n",
-    "    pass;"
+    "    pass;\n"
    ]
   }
  ],

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -112,9 +112,11 @@ def test_black_works_with_trailing_semicolons(
         '-    "import glob;\\n",\n'
         '+    "import glob\\n",\n'
         '-    "def func(a, b):\\n",\n'
+        '-    "    pass;\\n"\n'
         '+    "def func(\\n",\n'
         '+    "    a, b\\n",\n'
         '+    "):\\n",\n'
+        '+    "    pass;"\n'
     )
     assert result == expected
 

--- a/tests/test_configs_work.py
+++ b/tests/test_configs_work.py
@@ -1,6 +1,5 @@
 """Check local config files are picked up by nbqa."""
 
-import os
 from pathlib import Path
 from textwrap import dedent
 from typing import TYPE_CHECKING
@@ -33,14 +32,9 @@ def test_configs_work(capsys: "CaptureFixture") -> None:
     Path(".flake8").unlink()
 
     # check out and err
-    out, err = capsys.readouterr()
-    notebook = os.path.abspath(
-        os.path.join("tests", "data", "notebook_starting_with_md.ipynb")
-    )
-    expected_out = f"{notebook}\n"
-    expected_err = ""
-    assert sorted(out.splitlines()) == sorted(expected_out.splitlines())
-    assert sorted(err.splitlines()) == sorted(expected_err.splitlines())
+    out, _ = capsys.readouterr()
+    expected_out = ""
+    assert out == expected_out
 
 
 def test_configs_work_in_setupcfg(capsys: "CaptureFixture") -> None:
@@ -83,14 +77,9 @@ def test_configs_work_in_setupcfg(capsys: "CaptureFixture") -> None:
     Path("setup.cfg").unlink()
 
     # check out and err
-    out, err = capsys.readouterr()
-    notebook = os.path.abspath(
-        os.path.join("tests", "data", "notebook_starting_with_md.ipynb")
-    )
-    expected_out = f"{notebook}\n"
-    expected_err = ""
-    assert sorted(out.splitlines()) == sorted(expected_out.splitlines())
-    assert sorted(err.splitlines()) == sorted(expected_err.splitlines())
+    out, _ = capsys.readouterr()
+    expected_out = ""
+    assert out == expected_out
 
 
 def test_configs_work_in_nbqaini(capsys: "CaptureFixture") -> None:
@@ -132,14 +121,8 @@ def test_configs_work_in_nbqaini(capsys: "CaptureFixture") -> None:
     Path(".nbqa.ini").unlink()
 
     # check out and err
-    out, err = capsys.readouterr()
-    notebook = os.path.abspath(
-        os.path.join("tests", "data", "notebook_starting_with_md.ipynb")
-    )
-    expected_out = f"{notebook}\n"
-    expected_err = ""
-    assert sorted(out.splitlines()) == sorted(expected_out.splitlines())
-    assert sorted(err.splitlines()) == sorted(expected_err.splitlines())
+    out, _ = capsys.readouterr()
+    assert out == ""
 
 
 def test_setupcfg_is_preserved(capsys: "CaptureFixture") -> None:
@@ -166,11 +149,5 @@ def test_setupcfg_is_preserved(capsys: "CaptureFixture") -> None:
         main(["flake8", "tests", "--ignore", "E302"])
 
     # check out and err
-    out, err = capsys.readouterr()
-    notebook = os.path.abspath(
-        os.path.join("tests", "data", "notebook_starting_with_md.ipynb")
-    )
-    expected_out = f"{notebook}\n"
-    expected_err = ""
-    assert sorted(out.splitlines()) == sorted(expected_out.splitlines())
-    assert sorted(err.splitlines()) == sorted(expected_err.splitlines())
+    out, _ = capsys.readouterr()
+    assert out == ""

--- a/tests/test_flake8_works.py
+++ b/tests/test_flake8_works.py
@@ -50,7 +50,6 @@ def test_flake8_works(capsys: "CaptureFixture") -> None:
         {path_2}:cell_1:1:1: F401 'os' imported but unused
         {path_2}:cell_1:3:1: F401 'glob' imported but unused
         {path_2}:cell_1:5:1: F401 'nbqa' imported but unused
-        {path_2}:cell_3:0:1: E303 too many blank lines (3)
         {path_2}:cell_3:2:1: E302 expected 2 blank lines, found 0
         """
     )

--- a/tests/test_isort_works.py
+++ b/tests/test_isort_works.py
@@ -154,5 +154,10 @@ def test_isort_trailing_semicolon(tmp_notebook_with_trailing_semicolon: "Path") 
         after = handle.readlines()
     diff = difflib.unified_diff(before, after)
     result = "".join([i for i in diff if any([i.startswith("+ "), i.startswith("- ")])])
-    expected = '-    "import glob;\\n",\n+    "import glob\\n",\n'
+    expected = (
+        '-    "import glob;\\n",\n'
+        '+    "import glob\\n",\n'
+        '-    "    pass;\\n"\n'
+        '+    "    pass;"\n'
+    )
     assert result == expected

--- a/tests/test_pyproject_toml.py
+++ b/tests/test_pyproject_toml.py
@@ -1,6 +1,5 @@
 """Check configs from :code:`pyproject.toml` are picked up."""
 
-import os
 from pathlib import Path
 from textwrap import dedent
 from typing import TYPE_CHECKING
@@ -45,11 +44,6 @@ def test_pyproject_toml_works(
     Path(filename).unlink()
 
     # check out and err
-    out, err = capsys.readouterr()
-    notebook = os.path.abspath(
-        os.path.join("tests", "data", "notebook_starting_with_md.ipynb")
-    )
-    expected_out = f"{notebook}\n"
-    expected_err = ""
-    assert sorted(out.splitlines()) == sorted(expected_out.splitlines())
-    assert sorted(err.splitlines()) == sorted(expected_err.splitlines())
+    out, _ = capsys.readouterr()
+    expected_out = ""
+    assert out == expected_out

--- a/tests/test_setupcfg.py
+++ b/tests/test_setupcfg.py
@@ -1,6 +1,5 @@
 """Check configs from :code:`setup.cfg` are picked up."""
 
-import os
 from pathlib import Path
 from textwrap import dedent
 from typing import TYPE_CHECKING
@@ -40,11 +39,6 @@ def test_nbqa_ini_works(capsys: "CaptureFixture") -> None:
     Path("setup.cfg").unlink()
 
     # check out and err
-    out, err = capsys.readouterr()
-    notebook = os.path.abspath(
-        os.path.join("tests", "data", "notebook_starting_with_md.ipynb")
-    )
-    expected_out = f"{notebook}\n"
-    expected_err = ""
-    assert sorted(out.splitlines()) == sorted(expected_out.splitlines())
-    assert sorted(err.splitlines()) == sorted(expected_err.splitlines())
+    out, _ = capsys.readouterr()
+    expected_out = ""
+    assert out == expected_out


### PR DESCRIPTION
closes #265 

This solves a bug but also allows for quite some simplification. I don't know why anyone would purposefully have a newline at the end of a cell so I think it's OK to remove it, so long as the behaviour's documented.