### PR TITLE
Skip processing cells containing cell magics.

### DIFF
--- a/nbqa/notebook_info.py
+++ b/nbqa/notebook_info.py
@@ -1,0 +1,70 @@
+"""Store information about the code cells for processing."""
+from typing import Dict, Mapping, Set
+
+
+class NotebookInfo:
+    """
+    Store information about notebook cells used for processing.
+
+    Attributes
+    ----------
+    cell_mapping
+        Mapping from Python line numbers to Jupyter notebooks cells.
+    trailing_semicolons
+        Cell numbers where there were originally trailing semicolons.
+    temporary_lines
+        Mapping from temporary lines to original lines.
+    code_cells_to_ignore
+        List of code cell to ignore when modifying the source notebook.
+    """
+
+    _cell_mappings: Dict[int, str] = {}
+    _trailing_semicolons: Set[int] = set()
+    _temporary_lines: Dict[str, str] = {}
+    _code_cells_to_ignore: Set[int] = set()
+
+    def __init__(
+        self,
+        cell_mappings: Dict[int, str],
+        trailing_semicolons: Set[int],
+        temporary_lines: Dict[str, str],
+        code_cells_to_ignore: Set[int],
+    ) -> None:
+        """
+        Initialize current NotebookInfo instance.
+
+        Parameters
+        ----------
+        cell_mappings : Dict[int, str]
+            Mapping from Python line numbers to Jupyter notebooks cells.
+        trailing_semicolons : Set[int]
+            Cell numbers where there were originally trailing semicolons.
+        temporary_lines : Dict[str, str]
+            Mapping from temporary lines to original lines.
+        code_cells_to_ignore : Set[int]
+            List of cell numbers to ignore when modifying the source notebook.
+        """
+        self._cell_mappings = cell_mappings
+        self._trailing_semicolons = trailing_semicolons
+        self._temporary_lines = temporary_lines
+        self._code_cells_to_ignore = code_cells_to_ignore
+
+    @property
+    def cell_mappings(self) -> Mapping[int, str]:
+        """Return mapping from Python line numbers to Jupyter notebooks cells."""
+        return self._cell_mappings
+
+    @property
+    def trailing_semicolons(self) -> Set[int]:
+        """Return cell numbers where there were originally trailing semicolons."""
+        return self._trailing_semicolons
+
+    @property
+    def temporary_lines(self) -> Mapping[str, str]:
+        """Return mapping from temporary lines to original lines."""
+        return self._temporary_lines
+
+    @property
+    def code_cells_to_ignore(self) -> Set[int]:
+        """Return code cell numbers to ignore when modifying the source notebook."""
+        return self._code_cells_to_ignore

--- a/nbqa/replace_source.py
+++ b/nbqa/replace_source.py
@@ -5,20 +5,50 @@ The converted file will have had the third-party tool run against it by now.
 """
 
 import json
-from typing import TYPE_CHECKING, Dict, List
+from typing import TYPE_CHECKING, Iterator, List, Mapping, Set
 
+from nbqa.notebook_info import NotebookInfo
 from nbqa.save_source import CODE_SEPARATOR
 
 if TYPE_CHECKING:
     from pathlib import Path
 
 
-def main(
-    python_file: "Path",
-    notebook: "Path",
-    trailing_semicolons: List[int],
-    temporary_lines: Dict[str, str],
-) -> None:
+def _reinstate_magics(
+    source: str,
+    cell_number: int,
+    trailing_semicolons: Set[int],
+    temporary_lines: Mapping[str, str],
+) -> List[str]:
+    """
+    Put (preprocessed) line magics back in.
+
+    Parameters
+    ----------
+    source
+        Portion of Python file between cell separators.
+    cell_number
+        Number of current cell.
+    trailing_semicolons
+        List of cells which originally had trailing semicolons.
+    temporary_lines
+        Mapping from temporary lines to original lines.
+
+    Returns
+    -------
+    List[str]
+        New source that can be saved into Jupyter Notebook.
+    """
+    rstripped_source = source.rstrip()
+    if cell_number in trailing_semicolons and not rstripped_source.endswith(";"):
+        source = rstripped_source + ";"
+    # we take [1:] because the first cell is just '\n'
+    for key, val in temporary_lines.items():
+        source = source.replace(key, val)
+    return "\n{}".format(source.strip("\n")).splitlines(True)[1:]
+
+
+def main(python_file: "Path", notebook: "Path", notebook_info: NotebookInfo) -> None:
     """
     Replace :code:`source` code cells of original notebook.
 
@@ -28,10 +58,8 @@ def main(
         Temporary Python file notebook was converted to.
     notebook
         Jupyter Notebook third-party tool is run against (unmodified).
-    trailing_semicolons
-        Cells which originally had trailing semicolons.
-    temporary_lines
-        Mapping from temporary lines to original lines.
+    notebook_info
+        Information about notebook cells used for processing
     """
     with open(notebook) as handle:
         notebook_json = json.load(handle)
@@ -39,56 +67,21 @@ def main(
     with open(str(python_file)) as handle:
         pyfile = handle.read()
 
-    pycells = pyfile[len(CODE_SEPARATOR) :].split(CODE_SEPARATOR)
-
-    def _reinstate_magics(
-        source: str,
-        trailing_semicolons: List[int],
-        cell_number: int,
-        temporary_lines: Dict[str, str],
-    ) -> List[str]:
-        """
-        Put (commented-out) magics back in.
-
-        Parameters
-        ----------
-        source
-            Portion of Python file between cell separators.
-        trailing_semicolons
-            List of cells which originally had trailing semicolons.
-        cell_number
-            Number of current cell.
-        temporary_lines
-            Mapping from temporary lines to original lines.
-
-        Returns
-        -------
-        List[str]
-            New source that can be saved into Jupyter Notebook.
-        """
-        rstripped_source = source.rstrip()
-        if cell_number in trailing_semicolons and not rstripped_source.endswith(";"):
-            source = rstripped_source + ";"
-        # we take [1:] because the first cell is just '\n'
-        for key, val in temporary_lines.items():
-            source = source.replace(key, val)
-        return "\n{}".format(source.strip("\n")).splitlines(True)[1:]
-
-    new_sources = (
-        {
-            "source": _reinstate_magics(i, trailing_semicolons, n, temporary_lines),
-            "cell_type": "code",
-        }
-        for n, i in enumerate(pycells)
-    )
-
+    pycells: Iterator[str] = iter(pyfile[len(CODE_SEPARATOR) :].split(CODE_SEPARATOR))
+    code_cell_number = 0
     new_cells = []
-    for i in notebook_json["cells"]:
-        if i["cell_type"] == "markdown":
-            new_cells.append(i)
-            continue
-        i["source"] = next(new_sources)["source"]
-        new_cells.append(i)
+    for cell in notebook_json["cells"]:
+        if cell["cell_type"] == "code":
+            code_cell_number += 1
+            if code_cell_number not in notebook_info.code_cells_to_ignore:
+                cell["source"] = _reinstate_magics(
+                    next(pycells),
+                    code_cell_number,
+                    notebook_info.trailing_semicolons,
+                    notebook_info.temporary_lines,
+                )
+
+        new_cells.append(cell)
 
     notebook_json.update({"cells": new_cells})
     with open(notebook, "w") as handle:

--- a/nbqa/replace_source.py
+++ b/nbqa/replace_source.py
@@ -42,9 +42,9 @@ def _reinstate_magics(
     rstripped_source = source.rstrip()
     if cell_number in trailing_semicolons and not rstripped_source.endswith(";"):
         source = rstripped_source + ";"
-    # we take [1:] because the first cell is just '\n'
     for key, val in temporary_lines.items():
         source = source.replace(key, val)
+    # we take [1:] because the first cell is just '\n'
     return "\n{}".format(source.strip("\n")).splitlines(True)[1:]
 
 

--- a/nbqa/save_source.py
+++ b/nbqa/save_source.py
@@ -34,11 +34,7 @@ def _replace_line_magics(source: List[str]) -> Iterator[Tuple[str, Optional[str]
         Lines from cell, with line magics replaced with python code
     """
     for line in source:
-        if (
-            line.lstrip().startswith("!")
-            or line.lstrip().startswith("%")
-            or line.rstrip().endswith("?")
-        ):
+        if line.lstrip().startswith(("!", "%", "?")) or line.rstrip().endswith("?"):
             token = secrets.token_hex(3)
             # Replace line with `pass`.
             replacement = IGNORE_LINE_REPLACEMENT

--- a/nbqa/save_source.py
+++ b/nbqa/save_source.py
@@ -9,51 +9,40 @@ import secrets
 from itertools import takewhile
 from typing import TYPE_CHECKING, Dict, Iterator, List, Optional, Tuple
 
+from nbqa.notebook_info import NotebookInfo
+
 if TYPE_CHECKING:
     from pathlib import Path
 
 CODE_SEPARATOR = "# %%"
 MAGIC = ["%%script", "%%bash"]
-IGNORE_CELL_REPLACEMENT = "# nbqa"
 IGNORE_LINE_REPLACEMENT = "pass  # nbqa"
 
 
-def _replace_magics(
-    source: List[str], ignore_cells: List[str]
-) -> Iterator[Tuple[str, Optional[str]]]:
+def _replace_line_magics(source: List[str]) -> Iterator[Tuple[str, Optional[str]]]:
     """
-    Comment out lines with magic commands.
-
-    If it's a script/bash cell, comment out the entire cell.
+    Replace IPython line magics with valid python code.
 
     Parameters
     ----------
     source
         Source from notebook cell.
-    ignore_cells
-        Extra cells which nbqa should ignore.
 
     Yields
     ------
     str
-        Line from cell, possibly commented out.
+        Lines from cell, with line magics replaced with python code
     """
-    ignore = MAGIC + [i.strip() for i in ignore_cells]
-
-    ignore_cell = source and any(source[0].lstrip().startswith(i) for i in ignore)
     for line in source:
         if (
-            line.lstrip().startswith("!") or line.lstrip().startswith("%")
-        ) or ignore_cell:
+            line.lstrip().startswith("!")
+            or line.lstrip().startswith("%")
+            or line.rstrip().endswith("?")
+        ):
             token = secrets.token_hex(3)
-            if ignore_cell:
-                # Comment out entire cell.
-                replacement = IGNORE_CELL_REPLACEMENT
-                leading_space = ""
-            else:
-                # Replace line with `pass`.
-                replacement = IGNORE_LINE_REPLACEMENT
-                leading_space = "".join(takewhile(lambda c: c == " ", line))
+            # Replace line with `pass`.
+            replacement = IGNORE_LINE_REPLACEMENT
+            leading_space = "".join(takewhile(lambda c: c == " ", line))
             line_tokenised = f"{leading_space}{replacement}{token}"
             if line.endswith("\n"):
                 line_tokenised += "\n"
@@ -64,20 +53,17 @@ def _replace_magics(
 
 def _parse_cell(
     source: List[str],
-    ignore_cells: List[str],
     temporary_lines: Dict[str, str],
 ) -> str:
     """
-    Parse cell, replacing magics with temporary lines.
+    Parse cell, replacing line magics with python code as placeholder.
 
     Parameters
     ----------
     source
         Source from notebook cell.
-    ignore_cells
-        Extra cells which nbqa should ignore.
     temporary_lines
-        Mapping from temporary lines to original lines.
+        Mapping from placeholder python code to the original statement(line magic).
 
     Returns
     -------
@@ -85,7 +71,7 @@ def _parse_cell(
         Parsed cell.
     """
     parsed_cell = f"\n{CODE_SEPARATOR}\n"
-    for new, old in _replace_magics(source, ignore_cells):
+    for new, old in _replace_line_magics(source):
         parsed_cell += new
         if old is not None:
             temporary_lines[new] = old
@@ -93,11 +79,31 @@ def _parse_cell(
     return parsed_cell
 
 
+def _should_ignore_code_cell(source: List[str], ignore_cells: List[str]) -> bool:
+    """
+    Return True if the current cell should be ignored from processing.
+
+    Parameters
+    ----------
+    source : List[str]
+        Source from the notebook cell
+    ignore_cells : List[str]
+        Extra cells which nbqa should ignore.
+
+    Returns
+    -------
+    bool
+        True if the cell should ignored else False
+    """
+    ignore = MAGIC + [i.strip() for i in ignore_cells]
+    return source != [] and any(source[0].lstrip().startswith(i) for i in ignore)
+
+
 def main(
     notebook: "Path",
     temp_python_file: "Path",
     ignore_cells: List[str],
-) -> Tuple[Dict[int, str], List[int], Dict[str, str]]:
+) -> NotebookInfo:
     """
     Extract code cells from notebook and save them in temporary Python file.
 
@@ -112,12 +118,8 @@ def main(
 
     Returns
     -------
-    cell_mapping
-        Mapping from Python line numbers to Jupyter notebooks cells.
-    trailing_semicolons
-        Cell numbers where there were originally trailing semicolons.
-    temporary_lines
-        Mapping from temporary lines to original lines.
+    NotebookInfo
+
     """
     with open(notebook) as handle:
         cells = json.load(handle)["cells"]
@@ -126,27 +128,34 @@ def main(
     cell_mapping = {}
     line_number = 0
     cell_number = 0
-    trailing_semicolons = []
+    trailing_semicolons = set()
     temporary_lines: Dict[str, str] = {}
+    code_cells_to_ignore = set()
 
-    for i in cells:
-        if i["cell_type"] != "code":
-            continue
-        parsed_cell = _parse_cell(i["source"], ignore_cells, temporary_lines)
-        result.append(parsed_cell)
-        split_parsed_cell = parsed_cell.splitlines()
-        cell_mapping.update(
-            {
-                j + line_number + 1: f"cell_{cell_number+1}:{j}"
-                for j in range(len(split_parsed_cell))
-            }
-        )
-        if parsed_cell.rstrip().endswith(";"):
-            trailing_semicolons.append(cell_number)
-        line_number += len(split_parsed_cell)
-        cell_number += 1
+    for cell in cells:
+        if cell["cell_type"] == "code":
+            cell_number += 1
+
+            if _should_ignore_code_cell(cell["source"], ignore_cells):
+                code_cells_to_ignore.add(cell_number)
+                continue
+
+            parsed_cell = _parse_cell(cell["source"], temporary_lines)
+            result.append(parsed_cell)
+            split_parsed_cell = parsed_cell.splitlines()
+            cell_mapping.update(
+                {
+                    j + line_number + 1: f"cell_{cell_number}:{j}"
+                    for j in range(len(split_parsed_cell))
+                }
+            )
+            if parsed_cell.rstrip().endswith(";"):
+                trailing_semicolons.add(cell_number)
+            line_number += len(split_parsed_cell)
 
     with open(str(temp_python_file), "w") as handle:
         handle.write("".join(result)[len("\n") :])
 
-    return cell_mapping, trailing_semicolons, temporary_lines
+    return NotebookInfo(
+        cell_mapping, trailing_semicolons, temporary_lines, code_cells_to_ignore
+    )

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 current_version = 0.2.1
 
 [flake8]
-ignore = E203,E503,W504
+ignore = E203,E503,W503,W504
 max-line-length = 120
 exclude = venv,.*
 


### PR DESCRIPTION
Cell magics like %%script, %%bash and other custom cell magics configured via the ignore_cells configuration option will not be added to the temporary python file.

Changes to be committed:
	modified:   nbqa/__main__.py
	new file:   nbqa/notebook_info.py
	modified:   nbqa/replace_source.py
	modified:   nbqa/save_source.py
	modified:   setup.cfg