### PR TITLE
DOC document pre-commit usage separately

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,31 +93,15 @@ Rewriting my_notebook.ipynb
 
 ## 🔧 Configuration
 
-You can configure `nbQA` either at the command line, or by using a `pyproject.toml` file - see
+You can configure `nbqa` either at the command line, or by using a `pyproject.toml` file - see
 [configuration](https://nbqa.readthedocs.io/en/latest/configuration.html)
 for details and examples.
 
 ## 👷 Usage as pre-commit hook
 
-If you want to use `nbqa` with [pre-commit](https://pre-commit.com/),
-here\'s an example of what you could add to your
-`.pre-commit-config.yaml` file:
-
-```yaml
-- repo: https://github.com/nbQA-dev/nbQA
-  rev: 0.2.1
-  hooks:
-    - id: nbqa
-      args: ["flake8"]
-      name: nbqa-flake8
-      alias: nbqa-flake8
-      additional_dependencies: ["flake8"]
-    - id: nbqa
-      args: ["isort", "--nbqa-mutate"]
-      name: nbqa-isort
-      alias: nbqa-isort
-      additional_dependencies: ["isort"]
-```
+You can easily use `nbqa` as a [pre-commit](https://pre-commit.com/) hook by passing your desired
+code quality tool in the `args` and `additional_dependencies` sections - see
+[usage as pre-commit hook](https://nbqa.readthedocs.io/en/latest/configuration.html) for examples.
 
 ## 💬 Testimonials
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ for details and examples.
 
 You can easily use `nbqa` as a [pre-commit](https://pre-commit.com/) hook by passing your desired
 code quality tool in the `args` and `additional_dependencies` sections - see
-[usage as pre-commit hook](https://nbqa.readthedocs.io/en/latest/configuration.html) for examples.
+[usage as pre-commit hook](https://nbqa.readthedocs.io/en/latest/pre-commit.html) for examples.
 
 ## 💬 Testimonials
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1,3 +1,5 @@
+.. _configuration:
+
 Configuration
 -------------
 
@@ -73,7 +75,7 @@ To ignore extra cells, you can use the :code:`--nbqa-ignore-cells` CLI argument,
 
     nbqa black my_notebook.ipynb --nbqa-ignore-cells %%html,%%cython
 
-, or the :code:`ignore_cells` option in your :code:`pyproject.toml` file, e.g.
+or the :code:`ignore_cells` option in your :code:`pyproject.toml` file, e.g.
 
 .. code-block:: toml
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -38,8 +38,8 @@ and "help wanted" is open to whoever wants to implement it.
 Write Documentation
 ~~~~~~~~~~~~~~~~~~~
 
-nbQA could always use more documentation, whether as part of the
-official nbQA docs, in docstrings, or even on the web in blog posts,
+nbqa could always use more documentation, whether as part of the
+official nbqa docs, in docstrings, or even on the web in blog posts,
 articles, and such.
 
 Submit Feedback

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,6 +10,7 @@ nbQA
 
    readme
    configuration
+   pre-commit
    authors
    history
 

--- a/docs/pre-commit.rst
+++ b/docs/pre-commit.rst
@@ -1,0 +1,37 @@
+========================
+Usage as pre-commit hook
+========================
+
+You can easily use `nbqa` as a `pre-commit <https://pre-commit.com/>`_ hook by passing your desired
+code quality tool in the ``args`` and ``additional_dependencies`` sections.
+
+For example, if you wanted to autoformat your notebooks using ``black``, check for style guide compliance with ``flake8``,
+and sort your imports using ``isort``, you could put the following in your ``.pre-commit-config.yaml`` file ::
+
+    repos:
+    - repo: 'https://github.com/nbQA-dev/nbQA'
+        rev: 0.2.1
+        hooks:
+        - id: nbqa
+            args:
+            - black
+            name: nbqa-black
+            alias: nbqa-black
+            additional_dependencies:
+            - black
+        - id: nbqa
+            args:
+            - flake8
+            name: nbqa-flake8
+            alias: nbqa-flake8
+            additional_dependencies:
+            - flake8
+        - id: nbqa
+            args:
+            - isort
+            name: nbqa-isort
+            alias: nbqa-isort
+            additional_dependencies:
+            - isort
+
+See :ref:`configuration<configuration>` for how to further configure ``nbqa``.

--- a/nbqa/__main__.py
+++ b/nbqa/__main__.py
@@ -391,7 +391,7 @@ def _run_command(
     if "No module named" in err:
         raise ValueError(
             f"Command `{command}` not found. "
-            "Please make sure you have it installed before running nbQA on it."
+            "Please make sure you have it installed before running nbqa on it."
         )
 
     return out, err, output_code, mutated

--- a/nbqa/cmdline.py
+++ b/nbqa/cmdline.py
@@ -121,7 +121,7 @@ class CLIArgs:
             ),
         )
         parser.add_argument(
-            "--version", action="version", version=f"nbQA {__version__}"
+            "--version", action="version", version=f"nbqa {__version__}"
         )
         try:
             args, cmd_args = parser.parse_known_args(raw_args)

--- a/tests/test_missing_command.py
+++ b/tests/test_missing_command.py
@@ -14,7 +14,7 @@ def test_missing_command() -> None:
     command = "some-fictional-command"
     msg = (
         f"Command `{command}` not found. "
-        "Please make sure you have it installed before running nbQA on it."
+        "Please make sure you have it installed before running nbqa on it."
     )
     with pytest.raises(ValueError, match=msg):
         main([command, "tests", "--some-flag"])

--- a/tests/test_no_inits.py
+++ b/tests/test_no_inits.py
@@ -1,4 +1,4 @@
-"""Check that nbQA still works even if __init__ files aren't present."""
+"""Check that nbqa still works even if __init__ files aren't present."""
 
 import os
 import subprocess


### PR DESCRIPTION
Also, am changing to use `nbqa` (lowercase) when describing the package (unless it's in a title), as that's what you run from the command-line