### PR TITLE
Add workflow to autoupdate '.pre-commit-config.yaml'

### DIFF
--- a/.github/workflows/autoupdate-pre-commit-config.yml
+++ b/.github/workflows/autoupdate-pre-commit-config.yml
@@ -1,0 +1,33 @@
+name: "Update pre-commit config"
+# You need to set an access token as a secret ACTION_TRIGGER_TOKEN on this repo
+# in order for the PR to trigger the CI.
+# For more details see: https://github.com/technote-space/create-pr-action#github_token
+# If you don't want the PR to trigger the CI (NOT RECOMMENDED), comment out the GITHUB_TOKEN line.
+
+on:
+  schedule:
+    - cron: "0 7 * * 1" # At 07:00 on each Monday.
+  workflow_dispatch:
+
+jobs:
+  update-pre-commit:
+    name: Autoupdate pre-commit config
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v2
+      - uses: actions/cache@v2
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-autoupdate
+      - name: Update pre-commit config packages
+        uses: technote-space/create-pr-action@v2
+        with:
+          GITHUB_TOKEN: ${{ secrets.ACTION_TRIGGER_TOKEN }}
+          EXECUTE_COMMANDS: |
+            pip install pre-commit
+            pre-commit autoupdate || (exit 0);
+            pre-commit run -a || (exit 0);
+          COMMIT_MESSAGE: "⬆️ UPGRADE: Autoupdate pre-commit config"
+          PR_BRANCH_NAME: "pre-commit-config-update-${PR_ID}"
+          PR_TITLE: "⬆️ UPGRADE: Autoupdate pre-commit config"


### PR DESCRIPTION
This adds a workflow which runs `pre-commit autoupdate` on schedule or manually triggered with `workflow_dispatch`, and makes a PR if there are new versions of tool.

@MarcoGorelli In order for this to trigger the CI at PR's you need [create an access token](https://github.com/technote-space/create-pr-action#github_token) and add it as secret `ACTION_TRIGGER_TOKEN` to the repo.