### PR TITLE
Different approach to replace line magics with a valid python source …

### DIFF
--- a/nbqa/save_source.py
+++ b/nbqa/save_source.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 
 CODE_SEPARATOR = "# %%"
 MAGIC = ["%%script", "%%bash"]
-IGNORE_LINE_REPLACEMENT = "pass  # nbqa"
+IGNORE_LINE_REPLACEMENT = '__import__("nbqa.util", fromlist=["nbqa"]).no_op("{}")'
 
 
 def _is_src_code_indentation_valid(source: str) -> bool:
@@ -69,7 +69,7 @@ def _handle_line_magic_indentation(
     token = secrets.token_hex(3)
 
     # preserve the leading spaces and check if the syntax is valid
-    line_tokenised = f"{leading_space}{IGNORE_LINE_REPLACEMENT}{token}"
+    line_tokenised = f"{leading_space}{IGNORE_LINE_REPLACEMENT.format(token)}"
 
     if leading_space and not _is_src_code_indentation_valid(
         "".join(source + [line_tokenised])

--- a/nbqa/util.py
+++ b/nbqa/util.py
@@ -1,0 +1,6 @@
+"""Module with helper utils to handle line magics in the notebook source."""
+
+
+def no_op(_: str) -> None:
+    """Do nothing."""
+    return


### PR DESCRIPTION
This is just a different approach to replace line magics with a valid python source code. Ignore the CI failures (failing due to code coverage). **This will not be commited**. This PR is just to demonstrate the approach.

Here we define a `no_op` function in nbqa itself, and calling that function in place of line magics using `__import__`. So the replacement python code will be `IGNORE_LINE_REPLACEMENT = '__import__("nbqa.util", fromlist=["nbqa"]).no_op("{}")'
` instead of `IGNORE_LINE_REPLACEMENT = "pass  # nbqa"`

* I don't think anyone will use this code in a notebook, since this code is internal to the `nbqa`.
* Actually the statement does nothing so no issues caused to tools like `doctest`.
* Passes all linter checks, mypy checks and formatters

Any comments/thoughts on this approach? Would it be an issue when used with some other tool?