### PR TITLE
Remove the spaces from the temporary python file name

### DIFF
--- a/nbqa/__main__.py
+++ b/nbqa/__main__.py
@@ -62,9 +62,10 @@ def _temp_python_file_for_notebook(
         Temporary Python file whose location mirrors that of the notebook, but
         inside the temporary directory.
     """
-    # Add 3 extra whitespaces because `ipynb` is 3 chars longer than `py`.
-    relative_notebook_dir = notebook.resolve().relative_to(project_root).parent
-    temp_python_file = Path(tmpdir) / relative_notebook_dir / f"{notebook.stem}   .py"
+    relative_notebook_path = (
+        notebook.resolve().relative_to(project_root).with_suffix(".py")
+    )
+    temp_python_file = Path(tmpdir) / relative_notebook_path
     temp_python_file.parent.mkdir(parents=True, exist_ok=True)
     return temp_python_file
 
@@ -102,8 +103,8 @@ def _replace_path_out_err(
     out = out.replace(str(temp_python_file.resolve()), str(notebook))
     err = err.replace(str(temp_python_file.resolve()), str(notebook))
 
-    out = out.replace(str(notebook.with_name(f"{notebook.stem}   .py")), str(notebook))
-    err = err.replace(str(notebook.with_name(f"{notebook.stem}   .py")), str(notebook))
+    out = out.replace(str(notebook.with_suffix(".py")), str(notebook))
+    err = err.replace(str(notebook.with_suffix(".py")), str(notebook))
 
     return out, err
 

--- a/tests/test_doctest.py
+++ b/tests/test_doctest.py
@@ -43,7 +43,7 @@ def test_doctest_works(capsys: "CaptureFixture") -> None:
     expected_out = dedent(
         f"""\
         **********************************************************************
-        File "{WRONG_EXAMPLE_NOTEBOOK}", cell_2:10, in notebook_for_testing_copy   .hello
+        File "{WRONG_EXAMPLE_NOTEBOOK}", cell_2:10, in notebook_for_testing_copy.hello
         Failed example:
             hello("goodbye")
         Expected:
@@ -52,7 +52,7 @@ def test_doctest_works(capsys: "CaptureFixture") -> None:
             'hello goodbye'
         **********************************************************************
         1 items had failures:
-           1 of   2 in notebook_for_testing_copy   .hello
+           1 of   2 in notebook_for_testing_copy.hello
         ***Test Failed*** 1 failures.
         """
     )


### PR DESCRIPTION
…file name.

Spaces in the file name cause pylint to raise warning on `module name not conforming to snake_case`. This is the first change that addresses pylint support.

Changes to be committed:
	modified:   nbqa/`__main__.py`
	modified:   tests/test_doctest.py

closes #293 