### PR TITLE
Pylint support. Replace `pass` with `type` for handling magics

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,13 @@ $ nbqa pyupgrade my_notebook.ipynb --py36-plus --nbqa-mutate
 Rewriting my_notebook.ipynb
 ```
 
+Perform static code analysis with [pylint](https://www.pylint.org/):
+
+```bash
+$ nbqa pylint my_notebook.ipynb --disable=C0114
+my_notebook.ipynb:cell_1:5:0: W0611: Unused import nbqa (unused-import)
+```
+
 ## 🔧 Configuration
 
 You can configure `nbqa` either at the command line, or by using a `pyproject.toml` file - see

--- a/nbqa/__main__.py
+++ b/nbqa/__main__.py
@@ -155,13 +155,13 @@ def _replace_temp_python_file_references_in_out_err(
     # I couldn't reproduce this locally, but during CI, on the Windows job, I found
     # that VSSADM~1 was changing into VssAdministrator.
     temp_python_file_pattern = "{abs_path}|{rel_path}|{resolved_path}".format(
-        abs_path=str(temp_python_file),
-        rel_path=str(temp_python_file.relative_to(tmpdirname)),
-        resolved_path=str(temp_python_file.resolve()),
+        abs_path=re.escape(str(temp_python_file)),
+        rel_path=re.escape(str(temp_python_file.relative_to(tmpdirname))),
+        resolved_path=re.escape(str(temp_python_file.resolve())),
     )
 
-    out = re.sub(rf"{temp_python_file_pattern}", str(notebook), out)
-    err = re.sub(rf"{temp_python_file_pattern}", str(notebook), err)
+    out = re.sub(temp_python_file_pattern, str(notebook), out)
+    err = re.sub(temp_python_file_pattern, str(notebook), err)
     return out, err
 
 

--- a/nbqa/__main__.py
+++ b/nbqa/__main__.py
@@ -154,16 +154,14 @@ def _replace_temp_python_file_references_in_out_err(
     # is a symlink as well as no normalize the path.
     # I couldn't reproduce this locally, but during CI, on the Windows job, I found
     # that VSSADM~1 was changing into VssAdministrator.
-    temp_python_file_pattern = re.escape(
-        "{abs_path}|{rel_path}|{resolved_path}".format(
-            abs_path=str(temp_python_file),
-            rel_path=str(temp_python_file.relative_to(tmpdirname)),
-            resolved_path=str(temp_python_file.resolve()),
-        )
+    temp_python_file_pattern = "{abs_path}|{rel_path}|{resolved_path}".format(
+        abs_path=str(temp_python_file),
+        rel_path=str(temp_python_file.relative_to(tmpdirname)),
+        resolved_path=str(temp_python_file.resolve()),
     )
 
-    out = re.sub(temp_python_file_pattern, str(notebook), out)
-    err = re.sub(temp_python_file_pattern, str(notebook), err)
+    out = re.sub(rf"{temp_python_file_pattern}", str(notebook), out)
+    err = re.sub(rf"{temp_python_file_pattern}", str(notebook), err)
     return out, err
 
 

--- a/nbqa/__main__.py
+++ b/nbqa/__main__.py
@@ -154,10 +154,12 @@ def _replace_temp_python_file_references_in_out_err(
     # is a symlink as well as no normalize the path.
     # I couldn't reproduce this locally, but during CI, on the Windows job, I found
     # that VSSADM~1 was changing into VssAdministrator.
-    temp_python_file_pattern = r"{abs_path}|{rel_path}|{resolved_path}".format(
-        abs_path=str(temp_python_file),
-        rel_path=str(temp_python_file.relative_to(tmpdirname)),
-        resolved_path=str(temp_python_file.resolve()),
+    temp_python_file_pattern = re.escape(
+        "{abs_path}|{rel_path}|{resolved_path}".format(
+            abs_path=str(temp_python_file),
+            rel_path=str(temp_python_file.relative_to(tmpdirname)),
+            resolved_path=str(temp_python_file.resolve()),
+        )
     )
 
     out = re.sub(temp_python_file_pattern, str(notebook), out)

--- a/nbqa/__main__.py
+++ b/nbqa/__main__.py
@@ -154,14 +154,20 @@ def _replace_temp_python_file_references_in_out_err(
     # is a symlink as well as no normalize the path.
     # I couldn't reproduce this locally, but during CI, on the Windows job, I found
     # that VSSADM~1 was changing into VssAdministrator.
-    temp_python_file_pattern = "{abs_path}|{rel_path}|{resolved_path}".format(
-        abs_path=re.escape(str(temp_python_file)),
-        rel_path=re.escape(str(temp_python_file.relative_to(tmpdirname))),
-        resolved_path=re.escape(str(temp_python_file.resolve())),
+    paths = (
+        str(path)
+        for path in [
+            temp_python_file,
+            temp_python_file.resolve(),
+            temp_python_file.relative_to(tmpdirname),
+        ]
     )
 
-    out = re.sub(temp_python_file_pattern, str(notebook), out)
-    err = re.sub(temp_python_file_pattern, str(notebook), err)
+    notebook_path = str(notebook)
+    for path in paths:
+        out = out.replace(path, notebook_path)
+        err = err.replace(path, notebook_path)
+
     return out, err
 
 

--- a/nbqa/handle_magics.py
+++ b/nbqa/handle_magics.py
@@ -1,0 +1,48 @@
+"""Detect Ipython magics and provide python code replacements for those magics."""
+from typing import Callable, Mapping
+
+# Magic replacement templates
+_DEFAULT_TEMPLATE: str = 'type(""" {magic} """)  # {token}'
+
+# We use a comment for replacing cell magic, since we don't want
+# cell magic statements to be formatted
+# For instance a cell magic placed above a function will be
+# formatted to be separated by two blank lines from the function
+# It would look odd to have a cell magic followed by blank lines.
+_CELL_MAGIC_TEMPLATE: str = "# CELL_MAGIC {magic} {token}"
+
+
+def is_ipython_magic(source: str) -> bool:
+    return source.startswith(("!", "%", "?")) or source.endswith("?")
+
+
+def _get_default_replacement(token: str, magic: str) -> str:
+    return _DEFAULT_TEMPLATE.format(magic=magic, token=token)
+
+
+def _get_cell_or_line_magic_replacement(token: str, magic: str) -> str:
+    if magic.startswith("%%"):
+        return _get_cell_magic_replacement(token, magic)
+
+    return _get_default_replacement(token, magic)
+
+
+def _get_cell_magic_replacement(token: str, magic: str) -> str:
+    return _CELL_MAGIC_TEMPLATE.format(magic=magic, token=token)
+
+
+_MAGIC_HANDLERS: Mapping[str, Callable[..., str]] = {
+    "!": _get_default_replacement,
+    "?": _get_default_replacement,
+    "%": _get_cell_or_line_magic_replacement,
+}
+
+
+def get_magic_replacement(ipython_magic: str, token: str) -> str:
+    replacement_line: str = _MAGIC_HANDLERS.get(
+        ipython_magic[0],
+        # This is to handle magic like str.split??
+        _MAGIC_HANDLERS.get(ipython_magic[-1], _get_default_replacement),
+    )(token, ipython_magic)
+
+    return replacement_line

--- a/nbqa/handle_magics.py
+++ b/nbqa/handle_magics.py
@@ -1,6 +1,7 @@
 """Detect ipython magics and provide python code replacements for those magics."""
 import re
 import secrets
+from abc import ABC
 from typing import Pattern, Tuple
 
 
@@ -63,7 +64,7 @@ class MagicSubstitution:
         return f"{spaces}{self.replacement_line}"
 
 
-class MagicHandler:
+class MagicHandler(ABC):
     """Base class of different types of magic handlers."""
 
     # Here token is placed at the beginning and at the end so that
@@ -184,8 +185,6 @@ class MagicHandler:
                 magic_handler = CellMagicHandler()
             else:
                 magic_handler = LineMagicHandler()
-        else:
-            magic_handler = MagicHandler()
 
         return magic_handler
 

--- a/nbqa/handle_magics.py
+++ b/nbqa/handle_magics.py
@@ -1,4 +1,5 @@
-"""Detect Ipython magics and provide python code replacements for those magics."""
+"""Detect ipython magics and provide python code replacements for those magics."""
+import secrets
 from typing import Callable, Mapping
 
 # Magic replacement templates
@@ -13,14 +14,57 @@ _CELL_MAGIC_TEMPLATE: str = "# CELL_MAGIC {magic} {token}"
 
 
 def is_ipython_magic(source: str) -> bool:
+    """
+    Return True if the source contains ipython magic.
+
+    Parameters
+    ----------
+    source : str
+        Source code present in the notebook cell.
+
+    Returns
+    -------
+    bool
+        True if the source contains ipython magic
+    """
     return source.startswith(("!", "%", "?")) or source.endswith("?")
 
 
 def _get_default_replacement(token: str, magic: str) -> str:
+    """
+    Return python code to be replace the input ipython magic.
+
+    Parameters
+    ----------
+    token : str
+        Token to uniquely identify the replacement python code
+    magic : str
+        IPython magic statement
+
+    Returns
+    -------
+    str
+        Python code to replace the ipython magic
+    """
     return _DEFAULT_TEMPLATE.format(magic=magic, token=token)
 
 
 def _get_cell_or_line_magic_replacement(token: str, magic: str) -> str:
+    """
+    Return python code the replaces the input ipython magic.
+
+    Parameters
+    ----------
+    token : str
+        Token to uniquely identity the replacement python code
+    magic : str
+        IPython cell or line magic present in the notebook cell
+
+    Returns
+    -------
+    str
+        Python code replacing the ipython magic
+    """
     if magic.startswith("%%"):
         return _get_cell_magic_replacement(token, magic)
 
@@ -28,6 +72,21 @@ def _get_cell_or_line_magic_replacement(token: str, magic: str) -> str:
 
 
 def _get_cell_magic_replacement(token: str, magic: str) -> str:
+    """
+    Return python code to replace the input ipython cell magic.
+
+    Parameters
+    ----------
+    token : str
+        Token to uniquely identify the replacement python code
+    magic : str
+        IPython magic present in the notebook cell
+
+    Returns
+    -------
+    str
+        Python code replacing the cell magic
+    """
     return _CELL_MAGIC_TEMPLATE.format(magic=magic, token=token)
 
 
@@ -38,7 +97,21 @@ _MAGIC_HANDLERS: Mapping[str, Callable[..., str]] = {
 }
 
 
-def get_magic_replacement(ipython_magic: str, token: str) -> str:
+def get_magic_replacement(ipython_magic: str) -> str:
+    """
+    Return python code to replace the ipython magic.
+
+    Parameters
+    ----------
+    ipython_magic : str
+        IPython magic statement present in the notebook cell
+
+    Returns
+    -------
+    str
+        Python code to be substituted for the ipython magic
+    """
+    token: str = secrets.token_hex(3)
     replacement_line: str = _MAGIC_HANDLERS.get(
         ipython_magic[0],
         # This is to handle magic like str.split??

--- a/nbqa/handle_magics.py
+++ b/nbqa/handle_magics.py
@@ -74,7 +74,7 @@ class MagicHandler(ABC):
     # we would run in to formatting issues like single quotes formatted
     # to double quotes or vice versa. `{token}` is used as hexadecimal number.
     _MAGIC_TEMPLATE: str = "type({token})  # {magic:10.10} {token}"
-    _MAGIC_REGEX_TEMPLATE: str = r"type\({token}\).*{token}"
+    _MAGIC_REGEX_TEMPLATE: str = r"type\s*\(\s*{token}\s*\).*{token}"
 
     def replace_magic(self, ipython_magic: str) -> MagicSubstitution:
         """

--- a/nbqa/notebook_info.py
+++ b/nbqa/notebook_info.py
@@ -16,7 +16,7 @@ class NotebookInfo:
     trailing_semicolons
         Cell numbers where there were originally trailing semicolons.
     temporary_lines
-        Mapping from temporary lines to original lines.
+        Mapping from cell number to all the magics substituted in those cell.
     code_cells_to_ignore
         List of code cell to ignore when modifying the source notebook.
     """
@@ -43,7 +43,7 @@ class NotebookInfo:
         trailing_semicolons : Set[int]
             Cell numbers where there were originally trailing semicolons.
         temporary_lines : Mapping[int, List[MagicSubstitution]]
-            Mapping from temporary lines to original lines.
+            Mapping from cell number to all the magics substituted in those cell.
         code_cells_to_ignore : Set[int]
             List of cell numbers to ignore when modifying the source notebook.
         """
@@ -64,7 +64,7 @@ class NotebookInfo:
 
     @property
     def temporary_lines(self) -> Mapping[int, List[MagicSubstitution]]:
-        """Return mapping from temporary lines to original lines."""
+        """Return mapping from cell number to all the magics substituted."""
         return self._temporary_lines
 
     @property

--- a/nbqa/notebook_info.py
+++ b/nbqa/notebook_info.py
@@ -1,5 +1,8 @@
 """Store information about the code cells for processing."""
-from typing import Dict, Mapping, Set
+
+from typing import List, Mapping, Set
+
+from nbqa.handle_magics import MagicSubstitution
 
 
 class NotebookInfo:
@@ -20,14 +23,14 @@ class NotebookInfo:
 
     _cell_mappings: Mapping[int, str] = {}
     _trailing_semicolons: Set[int] = set()
-    _temporary_lines: Mapping[int, Dict[str, str]] = {}
+    _temporary_lines: Mapping[int, List[MagicSubstitution]] = {}
     _code_cells_to_ignore: Set[int] = set()
 
     def __init__(
         self,
         cell_mappings: Mapping[int, str],
         trailing_semicolons: Set[int],
-        temporary_lines: Mapping[int, Dict[str, str]],
+        temporary_lines: Mapping[int, List[MagicSubstitution]],
         code_cells_to_ignore: Set[int],
     ) -> None:
         """
@@ -39,7 +42,7 @@ class NotebookInfo:
             Mapping from Python line numbers to Jupyter notebooks cells.
         trailing_semicolons : Set[int]
             Cell numbers where there were originally trailing semicolons.
-        temporary_lines : Mapping[int, Dict[str, str]]
+        temporary_lines : Mapping[int, List[MagicSubstitution]]
             Mapping from temporary lines to original lines.
         code_cells_to_ignore : Set[int]
             List of cell numbers to ignore when modifying the source notebook.
@@ -60,7 +63,7 @@ class NotebookInfo:
         return self._trailing_semicolons
 
     @property
-    def temporary_lines(self) -> Mapping[int, Dict[str, str]]:
+    def temporary_lines(self) -> Mapping[int, List[MagicSubstitution]]:
         """Return mapping from temporary lines to original lines."""
         return self._temporary_lines
 

--- a/nbqa/replace_source.py
+++ b/nbqa/replace_source.py
@@ -59,7 +59,7 @@ def _reinstate_magics(
     source
         Portion of Python file between cell separators.
     temporary_lines
-        Mapping from temporary lines to original lines.
+        Mapping from temporary magic substitutions to original ipython magics
 
     Returns
     -------

--- a/nbqa/replace_source.py
+++ b/nbqa/replace_source.py
@@ -5,8 +5,9 @@ The converted file will have had the third-party tool run against it by now.
 """
 
 import json
-from typing import TYPE_CHECKING, Iterator, List, Mapping, Set
+from typing import TYPE_CHECKING, Iterator, List, Set
 
+from nbqa.handle_magics import MagicSubstitution
 from nbqa.notebook_info import NotebookInfo
 from nbqa.save_source import CODE_SEPARATOR
 
@@ -48,7 +49,7 @@ def _restore_semicolon(
 
 def _reinstate_magics(
     source: str,
-    temporary_lines: Mapping[str, str],
+    temporary_lines: List[MagicSubstitution],
 ) -> List[str]:
     """
     Put (preprocessed) line magics back in.
@@ -65,8 +66,8 @@ def _reinstate_magics(
     List[str]
         New source that can be saved into Jupyter Notebook.
     """
-    for key, val in temporary_lines.items():
-        source = source.replace(key, val)
+    for magic_substitution in temporary_lines:
+        source = magic_substitution.restore_magic(source)
     # we take [1:] because the first cell is just '\n'
     return "\n{}".format(source.strip("\n")).splitlines(True)[1:]
 
@@ -102,7 +103,7 @@ def main(python_file: "Path", notebook: "Path", notebook_info: NotebookInfo) -> 
                 )
                 cell["source"] = _reinstate_magics(
                     source,
-                    notebook_info.temporary_lines.get(code_cell_number, {}),
+                    notebook_info.temporary_lines.get(code_cell_number, []),
                 )
 
         new_cells.append(cell)

--- a/nbqa/save_source.py
+++ b/nbqa/save_source.py
@@ -6,7 +6,6 @@ Markdown cells, output, and metadata are ignored.
 
 import ast
 import json
-import secrets
 from collections import defaultdict
 from itertools import takewhile
 from typing import TYPE_CHECKING, DefaultDict, Dict, Iterator, List, Optional, Tuple
@@ -105,7 +104,7 @@ def _replace_line_magics(source: List[str]) -> Iterator[Tuple[str, Optional[str]
     for line_no, line in enumerate(source):
         trimmed_line: str = line.strip()
         if is_ipython_magic(trimmed_line):
-            replacement_line = get_magic_replacement(trimmed_line, secrets.token_hex(3))
+            replacement_line = get_magic_replacement(trimmed_line)
             yield _handle_magic_indentation(source[:line_no], line, replacement_line)
         else:
             yield line, None

--- a/nbqa/save_source.py
+++ b/nbqa/save_source.py
@@ -60,7 +60,7 @@ def _handle_magic_indentation(
     line_magic : str
         Line magic present in the notebook cell
     magic_replacement : MagicSubstitution
-        Replacement python code for the ipython magic
+        Object containing information on ipython magic replacement.
     Returns
     -------
     str
@@ -87,7 +87,7 @@ def _handle_magic_indentation(
 
 
 def _replace_magics(
-    source: List[str], temporary_lines: List[MagicSubstitution]
+    source: List[str], magic_substitutions: List[MagicSubstitution]
 ) -> Iterator[str]:
     """
     Replace IPython line magics with valid python code.
@@ -96,19 +96,21 @@ def _replace_magics(
     ----------
     source
         Source from notebook cell.
+    magic_substitutions
+        List to store all the ipython magics substitutions
 
     Yields
     ------
     str
-        Lines from cell, with line magics replaced with python code
+        Line from cell, with line magics replaced with python code
     """
     for line_no, line in enumerate(source):
         trimmed_line: str = line.strip()
         if MagicHandler.is_ipython_magic(trimmed_line):
             magic_handler = MagicHandler.get_magic_handler(trimmed_line)
             magic_substitution = magic_handler.replace_magic(trimmed_line)
+            magic_substitutions.append(magic_substitution)
             line = _handle_magic_indentation(source[:line_no], line, magic_substitution)
-            temporary_lines.append(magic_substitution)
 
         yield line
 
@@ -128,7 +130,7 @@ def _parse_cell(
     cell_number
         Number identifying the notebook cell.
     temporary_lines
-        Mapping from placeholder python code to the original statement(line magic).
+        Mapping to store the cell number to all the ipython magics replaced in those cells.
 
     Returns
     -------

--- a/nbqa/save_source.py
+++ b/nbqa/save_source.py
@@ -8,9 +8,9 @@ import ast
 import json
 from collections import defaultdict
 from itertools import takewhile
-from typing import TYPE_CHECKING, DefaultDict, Dict, Iterator, List, Optional, Tuple
+from typing import TYPE_CHECKING, DefaultDict, Dict, Iterator, List
 
-from nbqa.handle_magics import get_magic_replacement, is_ipython_magic
+from nbqa.handle_magics import MagicHandler, MagicSubstitution
 from nbqa.notebook_info import NotebookInfo
 
 if TYPE_CHECKING:
@@ -48,8 +48,8 @@ def _is_src_code_indentation_valid(source: str) -> bool:
 
 
 def _handle_magic_indentation(
-    source: List[str], line_magic: str, replacement_line: str
-) -> Tuple[str, str]:
+    source: List[str], line_magic: str, magic_replacement: MagicSubstitution
+) -> str:
     """
     Handle the indentation of line magics. Remove unnecessary indentation.
 
@@ -59,17 +59,17 @@ def _handle_magic_indentation(
         Source code of the notebook cell
     line_magic : str
         Line magic present in the notebook cell
-    replacement : str
+    magic_replacement : MagicSubstitution
         Replacement python code for the ipython magic
     Returns
     -------
-    Tuple[str, str]
-        Tuple of replacement line and the original line magic statement.
+    str
+        Replacement line for the original line magic statement.
     """
     leading_space = "".join(takewhile(lambda c: c == " ", line_magic))
 
     # preserve the leading spaces and check if the syntax is valid
-    replacement = f"{leading_space}{replacement_line}"
+    replacement = magic_replacement.indent_magic_replacement(leading_space)
 
     if leading_space and not _is_src_code_indentation_valid(
         "".join(source + [replacement])
@@ -78,16 +78,17 @@ def _handle_magic_indentation(
         # lead the source to have invalid indentation
         # Currently we don't check if the original source
         # code itself had IndentationError
-        replacement = replacement_line
-        line_magic = line_magic.lstrip()
+        replacement = magic_replacement.replacement_line
 
     if line_magic.endswith("\n"):
         replacement += "\n"
 
-    return replacement, line_magic
+    return replacement
 
 
-def _replace_line_magics(source: List[str]) -> Iterator[Tuple[str, Optional[str]]]:
+def _replace_magics(
+    source: List[str], temporary_lines: List[MagicSubstitution]
+) -> Iterator[str]:
     """
     Replace IPython line magics with valid python code.
 
@@ -103,15 +104,19 @@ def _replace_line_magics(source: List[str]) -> Iterator[Tuple[str, Optional[str]
     """
     for line_no, line in enumerate(source):
         trimmed_line: str = line.strip()
-        if is_ipython_magic(trimmed_line):
-            replacement_line = get_magic_replacement(trimmed_line)
-            yield _handle_magic_indentation(source[:line_no], line, replacement_line)
-        else:
-            yield line, None
+        if MagicHandler.is_ipython_magic(trimmed_line):
+            magic_handler = MagicHandler.get_magic_handler(trimmed_line)
+            magic_substitution = magic_handler.replace_magic(trimmed_line)
+            line = _handle_magic_indentation(source[:line_no], line, magic_substitution)
+            temporary_lines.append(magic_substitution)
+
+        yield line
 
 
 def _parse_cell(
-    source: List[str], cell_number: int, temporary_lines: Dict[int, Dict[str, str]]
+    source: List[str],
+    cell_number: int,
+    temporary_lines: Dict[int, List[MagicSubstitution]],
 ) -> str:
     """
     Parse cell, replacing line magics with python code as placeholder.
@@ -130,11 +135,15 @@ def _parse_cell(
     str
         Parsed cell.
     """
+    substituted_magics: List[MagicSubstitution] = []
     parsed_cell = f"\n{CODE_SEPARATOR}\n"
-    for new, old in _replace_line_magics(source):
-        parsed_cell += new
-        if old is not None:
-            temporary_lines[cell_number][new] = old
+
+    for parsed_line in _replace_magics(source, substituted_magics):
+        parsed_cell += parsed_line
+
+    if substituted_magics:
+        temporary_lines[cell_number] = substituted_magics
+
     parsed_cell = parsed_cell.rstrip("\n") + "\n"
     return parsed_cell
 
@@ -189,7 +198,7 @@ def main(
     line_number = 0
     cell_number = 0
     trailing_semicolons = set()
-    temporary_lines: DefaultDict[int, Dict[str, str]] = defaultdict(dict)
+    temporary_lines: DefaultDict[int, List[MagicSubstitution]] = defaultdict(list)
     code_cells_to_ignore = set()
 
     for cell in cells:

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -51,8 +51,6 @@ def test_black_works(
     diff = difflib.unified_diff(before, after)
     result = "".join([i for i in diff if any([i.startswith("+ "), i.startswith("- ")])])
     expected = (
-        '+    "\\n",\n'
-        '+    "\\n",\n'
         "-    \"    return 'hello {}'.format(name)\\n\",\n"
         '+    "    return \\"hello {}\\".format(name)\\n",\n'
         '-    "hello(3)   "\n'

--- a/tests/test_flake8_works.py
+++ b/tests/test_flake8_works.py
@@ -38,11 +38,11 @@ def test_flake8_works(capsys: "CaptureFixture") -> None:
         {path_0}:cell_1:3:1: F401 'glob' imported but unused
         {path_0}:cell_1:5:1: F401 'nbqa' imported but unused
         {path_0}:cell_2:19:9: W291 trailing whitespace
-        {path_0}:cell_2:2:1: E302 expected 2 blank lines, found 0
+        {path_0}:cell_2:2:1: E302 expected 2 blank lines, found 1
         {path_1}:cell_1:1:1: F401 'os' imported but unused
         {path_1}:cell_1:3:1: F401 'glob' imported but unused
         {path_1}:cell_1:5:1: F401 'nbqa' imported but unused
-        {path_1}:cell_2:2:1: E302 expected 2 blank lines, found 0
+        {path_1}:cell_2:2:1: E302 expected 2 blank lines, found 1
         {path_2}:cell_1:1:1: F401 'os' imported but unused
         {path_2}:cell_1:3:1: F401 'glob' imported but unused
         {path_2}:cell_1:5:1: F401 'nbqa' imported but unused

--- a/tests/test_other_magics.py
+++ b/tests/test_other_magics.py
@@ -18,7 +18,6 @@ if TYPE_CHECKING:
         (
             "--nbqa-ignore-cells=%%custommagic",
             [
-                "cell_2:3:1: E402 module level import not at top of file",
                 "cell_2:3:1: F401 'glob' imported but unused",
             ],
         ),
@@ -43,7 +42,6 @@ def test_cli(magic: str, expected: List[str], capsys: "CaptureFixture") -> None:
         (
             "ignore_cells=%%%%custommagic",
             [
-                "cell_2:3:1: E402 module level import not at top of file",
                 "cell_2:3:1: F401 'glob' imported but unused",
             ],
         ),
@@ -81,7 +79,6 @@ def test_ini(magic: str, expected: str, capsys: "CaptureFixture") -> None:
         (
             'flake8=["%%custommagic"]',
             [
-                "cell_2:3:1: E402 module level import not at top of file",
                 "cell_2:3:1: F401 'glob' imported but unused",
             ],
         ),

--- a/tests/test_pylint_works.py
+++ b/tests/test_pylint_works.py
@@ -1,7 +1,6 @@
 """Check that :code:`black` works as intended."""
 
 import os
-import re
 from typing import TYPE_CHECKING
 
 import pytest
@@ -48,8 +47,8 @@ def test_pylint_works(capsys: "CaptureFixture") -> None:
     # This is to ensure no additional warnings get generated apart
     # from the expected ones. This will also help to update the test when the
     # notebooks used for testing are modified later.
-    assert len(re.findall(rf"{str(notebook1)}:cell_", out)) == 4
-    assert len(re.findall(rf"{str(notebook2)}:cell_", out)) == 1
+    assert out.count(rf"{str(notebook1)}:cell_") == 4
+    assert out.count(rf"{str(notebook2)}:cell_") == 1
 
     assert all(warning in out for warning in notebook1_expected_warnings)
     assert all(warning in out for warning in notebook2_expected_warnings)

--- a/tests/test_pylint_works.py
+++ b/tests/test_pylint_works.py
@@ -1,0 +1,57 @@
+"""Check that :code:`black` works as intended."""
+
+import os
+import re
+from typing import TYPE_CHECKING
+
+import pytest
+
+from nbqa.__main__ import main
+
+if TYPE_CHECKING:
+    from _pytest.capture import CaptureFixture
+
+
+def test_pylint_works(capsys: "CaptureFixture") -> None:
+    """
+    Check pylint works. Check all the warnings raised by pylint on the notebook.
+
+    Parameters
+    ----------
+    capsys
+        Pytest fixture to capture stdout and stderr.
+    """
+    # Pass one file with absolute path and the other one with relative path
+    notebook1 = os.path.abspath(
+        os.path.join("tests", "data", "notebook_for_testing.ipynb")
+    )
+    notebook2 = os.path.join("tests", "data", "notebook_with_indented_magics.ipynb")
+
+    with pytest.raises(SystemExit):
+        main(["pylint", notebook1, notebook2, "--disable=C0114"])
+
+    notebook1_expected_warnings = [
+        f"{str(notebook1)}:cell_2:19:8: C0303: Trailing whitespace (trailing-whitespace)",
+        f"{str(notebook1)}:cell_1:1:0: W0611: Unused import os (unused-import)",
+        f"{str(notebook1)}:cell_1:3:0: W0611: Unused import glob (unused-import)",
+        f"{str(notebook1)}:cell_1:5:0: W0611: Unused import nbqa (unused-import)",
+    ]
+
+    notebook2_expected_warnings = [
+        f'{str(notebook2)}:cell_2:1:0: C0413: Import "from random import randint"'
+        + " should be placed at the top of the module (wrong-import-position)"
+    ]
+
+    # check out and err
+    out, err = capsys.readouterr()
+
+    # This is to ensure no additional warnings get generated apart
+    # from the expected ones. This will also help to update the test when the
+    # notebooks used for testing are modified later.
+    assert len(re.findall(rf"{str(notebook1)}:cell_", out)) == 4
+    assert len(re.findall(rf"{str(notebook2)}:cell_", out)) == 1
+
+    assert all(warning in out for warning in notebook1_expected_warnings)
+    assert all(warning in out for warning in notebook2_expected_warnings)
+
+    assert err == ""

--- a/tests/test_return_code.py
+++ b/tests/test_return_code.py
@@ -20,6 +20,15 @@ def test_flake8_return_code() -> None:
     assert result == expected
 
 
+def test_pylint_return_code() -> None:
+    """Check pylint returns 0 if it passes, 1 otherwise."""
+    output = subprocess.run(["nbqa", "pylint", DIRTY_NOTEBOOK])
+    assert output.returncode == 1
+
+    output = subprocess.run(["nbqa", "pylint", CLEAN_NOTEBOOK, "--disable=C0114"])
+    assert output.returncode == 0
+
+
 def test_black_return_code() -> None:
     """Check black returns 0 if it passes, 1 otherwise."""
     output = subprocess.run(["nbqa", "black", DIRTY_NOTEBOOK, "--check"])


### PR DESCRIPTION
This is required to support pylint. Using `pass` causes pylint to raise `unnecessary pass` warnings. Instead if we use builtin function `type` we are clean of any flake8 and pylint warnings.