### PR TITLE
Remove trailing semicolon before subprocessrun

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -20,6 +20,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: install-tox
         run: python -m pip install --upgrade tox virtualenv setuptools pip
+      - name: install-reqs
+        run: python -m pip install --upgrade requirements-dev.txt && python -m pip install --upgrade requirements.txt
       - name: run-tox
         run: tox -e py
       - name: Upload coverage to Codecov

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -21,7 +21,7 @@ jobs:
       - name: install-tox
         run: python -m pip install --upgrade tox virtualenv setuptools pip
       - name: install-reqs
-        run: python -m pip install --upgrade requirements-dev.txt && python -m pip install --upgrade requirements.txt
+        run: python -m pip install --upgrade -r requirements-dev.txt && python -m pip install --upgrade -r requirements.txt
       - name: run-tox
         run: tox -e py
       - name: Upload coverage to Codecov

--- a/nbqa/save_source.py
+++ b/nbqa/save_source.py
@@ -222,7 +222,7 @@ def main(
             )
             if parsed_cell.rstrip().endswith(";"):
                 trailing_semicolons.add(cell_number)
-            result.append(re.sub(r";(\s*)", "\\1", parsed_cell))
+            result.append(re.sub(r";(\s*)$", "\\1", parsed_cell))
             line_number += len(split_parsed_cell)
 
     with open(str(temp_python_file), "w") as handle:

--- a/nbqa/save_source.py
+++ b/nbqa/save_source.py
@@ -6,6 +6,7 @@ Markdown cells, output, and metadata are ignored.
 
 import ast
 import json
+import re
 from collections import defaultdict
 from itertools import takewhile
 from typing import TYPE_CHECKING, DefaultDict, Dict, Iterator, List
@@ -212,7 +213,6 @@ def main(
                 continue
 
             parsed_cell = _parse_cell(cell["source"], cell_number, temporary_lines)
-            result.append(parsed_cell)
             split_parsed_cell = parsed_cell.splitlines()
             cell_mapping.update(
                 {
@@ -222,6 +222,7 @@ def main(
             )
             if parsed_cell.rstrip().endswith(";"):
                 trailing_semicolons.add(cell_number)
+            result.append(re.sub(r";(\s*)", "\\1", parsed_cell))
             line_number += len(split_parsed_cell)
 
     with open(str(temp_python_file), "w") as handle:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,6 +69,28 @@ def tmp_notebook_for_testing(tmpdir: "LocalPath") -> Iterator[Path]:
 
 
 @pytest.fixture
+def tmp_notebook_with_multiline(tmpdir: "LocalPath") -> Iterator[Path]:
+    """
+    Make temporary copy of test notebook before it's operated on, then revert it.
+
+    Parameters
+    ----------
+    tmpdir
+        Pytest fixture, gives us a temporary directory.
+
+    Yields
+    ------
+    Path
+        Temporary copy of test notebook.
+    """
+    filename = Path("tests/data") / "clean_notebook_with_multiline.ipynb"
+    temp_file = Path(tmpdir) / "tmp.ipynb"
+    shutil.copy(str(filename), str(temp_file))
+    yield filename
+    shutil.copy(str(temp_file), str(filename))
+
+
+@pytest.fixture
 def tmp_notebook_starting_with_md(tmpdir: "LocalPath") -> Iterator[Path]:
     """
     Make temporary copy of test notebook before it's operated on, then revert it.

--- a/tests/data/clean_notebook_with_multiline.ipynb
+++ b/tests/data/clean_notebook_with_multiline.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "assert 1 + 1 == 2;"
+    "assert 1 + 1 == 2;  assert 1 + 1 == 2;"
    ]
   },
   {

--- a/tests/data/clean_notebook_with_trailing_semicolon.ipynb
+++ b/tests/data/clean_notebook_with_trailing_semicolon.ipynb
@@ -1,0 +1,41 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert 1 + 1 == 2;"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/tests/data/clean_notebook_with_trailing_semicolon.ipynb
+++ b/tests/data/clean_notebook_with_trailing_semicolon.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "assert 1 + 1 == 2;"
+    "assert 1 + 1 == 2; assert 1 + 1 == 2;"
    ]
   },
   {

--- a/tests/test_isort_works.py
+++ b/tests/test_isort_works.py
@@ -152,5 +152,11 @@ def test_isort_trailing_semicolon(tmp_notebook_with_trailing_semicolon: "Path") 
         after = handle.readlines()
     diff = difflib.unified_diff(before, after)
     result = "".join([i for i in diff if any([i.startswith("+ "), i.startswith("- ")])])
-    expected = '-    "import glob;\\n",\n+    "import glob\\n",\n'
+    expected = (
+        '-    "import glob;\\n",\n'
+        '+    "import glob\\n",\n'
+        '-    "    pass;\\n",\n'
+        '-    " "\n'
+        '+    "    pass;"\n'
+    )
     assert result == expected

--- a/tests/test_mypy_works.py
+++ b/tests/test_mypy_works.py
@@ -34,7 +34,7 @@ def test_mypy_works(capsys: "CaptureFixture") -> None:
         {path_2}:cell_3:18: error: Argument 1 to "hello" has incompatible type "int"; expected "str"
         {path_1}:cell_2:18: error: Argument 1 to "hello" has incompatible type "int"; expected "str"
         {path_0}:cell_2:19: error: Argument 1 to "hello" has incompatible type "int"; expected "str"
-        Found 3 errors in 3 files (checked 12 source files)
+        Found 3 errors in 3 files (checked 13 source files)
         """  # noqa
     )
     expected_err = ""

--- a/tests/test_mypy_works.py
+++ b/tests/test_mypy_works.py
@@ -34,7 +34,7 @@ def test_mypy_works(capsys: "CaptureFixture") -> None:
         {path_2}:cell_3:18: error: Argument 1 to "hello" has incompatible type "int"; expected "str"
         {path_1}:cell_2:18: error: Argument 1 to "hello" has incompatible type "int"; expected "str"
         {path_0}:cell_2:19: error: Argument 1 to "hello" has incompatible type "int"; expected "str"
-        Found 3 errors in 3 files (checked 11 source files)
+        Found 3 errors in 3 files (checked 12 source files)
         """  # noqa
     )
     expected_err = ""

--- a/tests/test_return_code.py
+++ b/tests/test_return_code.py
@@ -5,6 +5,9 @@ import subprocess
 
 DIRTY_NOTEBOOK = os.path.join("tests", "data", "notebook_for_testing.ipynb")
 CLEAN_NOTEBOOK = os.path.join("tests", "data", "clean_notebook.ipynb")
+CLEAN_NOTEBOOK_TRAILING_SEMICOLON = os.path.join(
+    "tests", "data", "clean_notebook_with_trailing_semicolon.ipynb"
+)
 
 
 def test_flake8_return_code() -> None:
@@ -37,6 +40,13 @@ def test_black_return_code() -> None:
     assert result == expected
 
     output = subprocess.run(["nbqa", "black", "--check", CLEAN_NOTEBOOK])
+    result = output.returncode
+    expected = 0
+    assert result == expected
+
+    output = subprocess.run(
+        ["nbqa", "black", "--check", CLEAN_NOTEBOOK_TRAILING_SEMICOLON]
+    )
     result = output.returncode
     expected = 0
     assert result == expected


### PR DESCRIPTION
closes #305 

The solution in this PR is to remove trailing semicolons _before_ saving the temporary Python file - we store where they are anyway so they'll get restored by `replace_source`, but like this we won't get false positives like those described in #305 