### PR TITLE
Special-case isort

### DIFF
--- a/nbqa/__main__.py
+++ b/nbqa/__main__.py
@@ -427,7 +427,10 @@ def _run_on_one_root_dir(
         for notebook, temp_python_file in nb_to_py_mapping.items():
             try:
                 nb_info_mapping[notebook] = save_source.main(
-                    notebook, temp_python_file, configs.nbqa_ignore_cells
+                    notebook,
+                    temp_python_file,
+                    configs.nbqa_ignore_cells,
+                    cli_args.command,
                 )
             except Exception as exc:
                 raise RuntimeError(

--- a/nbqa/save_source.py
+++ b/nbqa/save_source.py
@@ -219,6 +219,7 @@ def main(
             parsed_cell = _parse_cell(
                 cell["source"], cell_number, temporary_lines, command
             )
+            result.append(parsed_cell)
             cell_mapping.update(
                 {
                     j + line_number + 1: f"cell_{cell_number}:{j}"

--- a/tests/data/notebook_with_cell_after_def.ipynb
+++ b/tests/data/notebook_with_cell_after_def.ipynb
@@ -1,0 +1,47 @@
+{
+ "metadata": {
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": 3
+  },
+  "orig_nbformat": 2
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2,
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def add(num1, num2):\n",
+    "    return num1 + num2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "add(2, 3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ]
+}

--- a/tests/test_flake8_works.py
+++ b/tests/test_flake8_works.py
@@ -38,11 +38,9 @@ def test_flake8_works(capsys: "CaptureFixture") -> None:
         {path_0}:cell_1:3:1: F401 'glob' imported but unused
         {path_0}:cell_1:5:1: F401 'nbqa' imported but unused
         {path_0}:cell_2:19:9: W291 trailing whitespace
-        {path_0}:cell_2:2:1: E302 expected 2 blank lines, found 1
         {path_1}:cell_1:1:1: F401 'os' imported but unused
         {path_1}:cell_1:3:1: F401 'glob' imported but unused
         {path_1}:cell_1:5:1: F401 'nbqa' imported but unused
-        {path_1}:cell_2:2:1: E302 expected 2 blank lines, found 1
         {path_2}:cell_1:1:1: F401 'os' imported but unused
         {path_2}:cell_1:3:1: F401 'glob' imported but unused
         {path_2}:cell_1:5:1: F401 'nbqa' imported but unused

--- a/tests/test_mypy_works.py
+++ b/tests/test_mypy_works.py
@@ -34,11 +34,7 @@ def test_mypy_works(capsys: "CaptureFixture") -> None:
         {path_2}:cell_3:18: error: Argument 1 to "hello" has incompatible type "int"; expected "str"
         {path_1}:cell_2:18: error: Argument 1 to "hello" has incompatible type "int"; expected "str"
         {path_0}:cell_2:19: error: Argument 1 to "hello" has incompatible type "int"; expected "str"
-<<<<<<< HEAD
-        Found 3 errors in 3 files (checked 12 source files)
-=======
-        Found 3 errors in 3 files (checked 13 source files)
->>>>>>> origin/master
+        Found 3 errors in 3 files (checked 14 source files)
         """  # noqa
     )
     expected_err = ""

--- a/tests/test_mypy_works.py
+++ b/tests/test_mypy_works.py
@@ -34,7 +34,7 @@ def test_mypy_works(capsys: "CaptureFixture") -> None:
         {path_2}:cell_3:18: error: Argument 1 to "hello" has incompatible type "int"; expected "str"
         {path_1}:cell_2:18: error: Argument 1 to "hello" has incompatible type "int"; expected "str"
         {path_0}:cell_2:19: error: Argument 1 to "hello" has incompatible type "int"; expected "str"
-        Found 3 errors in 3 files (checked 11 source files)
+        Found 3 errors in 3 files (checked 12 source files)
         """  # noqa
     )
     expected_err = ""

--- a/tests/test_return_code.py
+++ b/tests/test_return_code.py
@@ -5,6 +5,9 @@ import subprocess
 
 DIRTY_NOTEBOOK = os.path.join("tests", "data", "notebook_for_testing.ipynb")
 CLEAN_NOTEBOOK = os.path.join("tests", "data", "clean_notebook.ipynb")
+NOTEBOOK_WITH_CELL_AFTER_DEF = os.path.join(
+    "tests", "data", "notebook_with_cell_after_def.ipynb"
+)
 
 
 def test_flake8_return_code() -> None:
@@ -37,6 +40,11 @@ def test_black_return_code() -> None:
     assert result == expected
 
     output = subprocess.run(["nbqa", "black", "--check", CLEAN_NOTEBOOK])
+    result = output.returncode
+    expected = 0
+    assert result == expected
+
+    output = subprocess.run(["nbqa", "black", "--check", NOTEBOOK_WITH_CELL_AFTER_DEF])
     result = output.returncode
     expected = 0
     assert result == expected


### PR DESCRIPTION
closes #309 
closes #293 

I couldn't think of a better way to do this than to special-case isort.

The idea is that generally the cell separator will be `f"\n\n{CODE_SEPARATOR}\n"`, except for `isort` when it'll be `f"\n{CODE_SEPARATOR}\n"`

@girip11 you'd suggested this in https://github.com/nbQA-dev/nbQA/issues/293#issuecomment-703712225 , 

> Adding two new lines seems to solve the problem

Special-casing isort to just have a single newline would solve the flake8 bug, and this new black bug.

I'm not a fan of special-casing, but...I have a feeling this might be the only way here