### PR TITLE
Github action: adding caching action to the tox.yml github action

### DIFF
--- a/.github/workflows/autoupdate-pre-commit-config.yml
+++ b/.github/workflows/autoupdate-pre-commit-config.yml
@@ -17,13 +17,16 @@ jobs:
     steps:
       - name: Set up Python
         uses: actions/setup-python@v2
-      - uses: actions/cache@v2
+      - name: Cache multiple paths
+        uses: actions/cache@v2
         with:
           path: |
              ~/.cache/pre-commit
+          key: pre-commit-autoupdate
+          path: |
              ~/.cache/pip
              ~\AppData\Local\pip\Cache
-          key: pre-commit-autoupdate
+          key: ${{ runner.os }}-build-${{ env.cache-name }}
       - name: Update pre-commit config packages
         uses: technote-space/create-pr-action@v2
         with:

--- a/.github/workflows/autoupdate-pre-commit-config.yml
+++ b/.github/workflows/autoupdate-pre-commit-config.yml
@@ -21,14 +21,12 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-             ~/.cache/pre-commit
-          key: pre-commit-autoupdate
-          path: |
-             ~/.cache/pip
-             /opt/hostedtoolcache/Python/
-             ~\AppData\Local\pip\Cache
-             c:\hostedtoolcache\windows\python\
-          key: ${{ runner.os }}-build-${{ env.cache-name }}
+            ~/.cache/pre-commit
+            ~/.cache/pip
+            /opt/hostedtoolcache/Python/
+            ~\AppData\Local\pip\Cache
+            c:\hostedtoolcache\windows\python\
+          key: pre-commit-autoupdate-${{ runner.os }}-build-${{ env.cache-name }}
       - name: Update pre-commit config packages
         uses: technote-space/create-pr-action@v2
         with:

--- a/.github/workflows/autoupdate-pre-commit-config.yml
+++ b/.github/workflows/autoupdate-pre-commit-config.yml
@@ -23,9 +23,6 @@ jobs:
           path: |
             ~/.cache/pre-commit
             ~/.cache/pip
-            /opt/hostedtoolcache/Python/*
-            ~\AppData\Local\pip\Cache
-            c:\hostedtoolcache\windows\python\*
           key: pre-commit-autoupdate-${{ runner.os }}-build
       - name: Update pre-commit config packages
         uses: technote-space/create-pr-action@v2

--- a/.github/workflows/autoupdate-pre-commit-config.yml
+++ b/.github/workflows/autoupdate-pre-commit-config.yml
@@ -25,7 +25,9 @@ jobs:
           key: pre-commit-autoupdate
           path: |
              ~/.cache/pip
+             /opt/hostedtoolcache/Python/
              ~\AppData\Local\pip\Cache
+             c:\hostedtoolcache\windows\python\
           key: ${{ runner.os }}-build-${{ env.cache-name }}
       - name: Update pre-commit config packages
         uses: technote-space/create-pr-action@v2

--- a/.github/workflows/autoupdate-pre-commit-config.yml
+++ b/.github/workflows/autoupdate-pre-commit-config.yml
@@ -23,10 +23,10 @@ jobs:
           path: |
             ~/.cache/pre-commit
             ~/.cache/pip
-            /opt/hostedtoolcache/Python/
+            /opt/hostedtoolcache/Python/*
             ~\AppData\Local\pip\Cache
-            c:\hostedtoolcache\windows\python\
-          key: pre-commit-autoupdate-${{ runner.os }}-build-${{ env.cache-name }}
+            c:\hostedtoolcache\windows\python\*
+          key: pre-commit-autoupdate-${{ runner.os }}-build
       - name: Update pre-commit config packages
         uses: technote-space/create-pr-action@v2
         with:

--- a/.github/workflows/autoupdate-pre-commit-config.yml
+++ b/.github/workflows/autoupdate-pre-commit-config.yml
@@ -19,7 +19,10 @@ jobs:
         uses: actions/setup-python@v2
       - uses: actions/cache@v2
         with:
-          path: ~/.cache/pre-commit
+          path: |
+             ~/.cache/pre-commit
+             ~/.cache/pip
+             ~\AppData\Local\pip\Cache
           key: pre-commit-autoupdate
       - name: Update pre-commit config packages
         uses: technote-space/create-pr-action@v2

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -15,10 +15,10 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-             ~/.cache/pip
-             /opt/hostedtoolcache/Python/
-             ~\AppData\Local\pip\Cache
-             c:\hostedtoolcache\windows\python\
+            ~/.cache/pip
+            /opt/hostedtoolcache/Python/
+            ~\AppData\Local\pip\Cache
+            c:\hostedtoolcache\windows\python\
           key: ${{ runner.os }}-build-${{ env.cache-name }}
       # This is required since pylint is used in pre-commit as a local hook
       - name: Install dependencies

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -16,7 +16,9 @@ jobs:
         with:
           path: |
              ~/.cache/pip
+             /opt/hostedtoolcache/Python/
              ~\AppData\Local\pip\Cache
+             c:\hostedtoolcache\windows\python\
           key: ${{ runner.os }}-build-${{ env.cache-name }}
       # This is required since pylint is used in pre-commit as a local hook
       - name: Install dependencies

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -17,7 +17,7 @@ jobs:
           path: |
              ~/.cache/pip
              ~\AppData\Local\pip\Cache
-          key: ${{ runner.os }}-${{ hashFiles('**lockfiles') }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}
       # This is required since pylint is used in pre-commit as a local hook
       - name: Install dependencies
         run: |

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,6 +11,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
+      - name: Cache multiple paths
+        uses: actions/cache@v2
+        with:
+          path: |
+             ~/.cache/pip
+             ~\AppData\Local\pip\Cache
+          key: ${{ runner.os }}-${{ hashFiles('**lockfiles') }}
       # This is required since pylint is used in pre-commit as a local hook
       - name: Install dependencies
         run: |

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,15 +11,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
-      - name: Cache multiple paths
-        uses: actions/cache@v2
         with:
-          path: |
-            ~/.cache/pre-commit
-          key: ${{ runner.os }}-build
-      # This is required since pylint is used in pre-commit as a local hook
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements-dev.txt
+          python-version: "3.8"
       - uses: pre-commit/action@v2.0.0

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -16,10 +16,10 @@ jobs:
         with:
           path: |
             ~/.cache/pip
-            /opt/hostedtoolcache/Python/
+            /opt/hostedtoolcache/Python/*
             ~\AppData\Local\pip\Cache
-            c:\hostedtoolcache\windows\python\
-          key: ${{ runner.os }}-build-${{ env.cache-name }}
+            c:\hostedtoolcache\windows\python\*
+          key: ${{ runner.os }}-build
       # This is required since pylint is used in pre-commit as a local hook
       - name: Install dependencies
         run: |

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -15,10 +15,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            ~/.cache/pip
-            /opt/hostedtoolcache/Python/*
-            ~\AppData\Local\pip\Cache
-            c:\hostedtoolcache\windows\python\*
+            ~/.cache/pre-commit
           key: ${{ runner.os }}-build
       # This is required since pylint is used in pre-commit as a local hook
       - name: Install dependencies

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -24,7 +24,7 @@ jobs:
           path: |
              ~/.cache/pip
              ~\AppData\Local\pip\Cache
-          key: ${{ runner.os }}-${{ hashFiles('**lockfiles') }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}
       - name: install-tox
         run: python -m pip install --upgrade tox virtualenv setuptools pip
       - name: install-reqs

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -23,10 +23,10 @@ jobs:
         with:
           path: |
             ~/.cache/pip
-            /opt/hostedtoolcache/Python/
+            /opt/hostedtoolcache/Python/*
             ~\AppData\Local\pip\Cache
-            c:\hostedtoolcache\windows\python\
-          key: ${{ runner.os }}-build-${{ env.cache-name }}
+            c:\hostedtoolcache\windows\python\*
+          key: ${{ runner.os }}-build-${{ matrix.python-version }}
       - name: install-tox
         run: python -m pip install --upgrade tox virtualenv setuptools pip
       - name: install-reqs

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -23,7 +23,9 @@ jobs:
         with:
           path: |
              ~/.cache/pip
+             /opt/hostedtoolcache/Python/
              ~\AppData\Local\pip\Cache
+             c:\hostedtoolcache\windows\python\
           key: ${{ runner.os }}-build-${{ env.cache-name }}
       - name: install-tox
         run: python -m pip install --upgrade tox virtualenv setuptools pip

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -23,9 +23,8 @@ jobs:
         with:
           path: |
             ~/.cache/pip
-            /opt/hostedtoolcache/Python/*
+            $RUNNER_TOOL_CACHE/Python/*
             ~\AppData\Local\pip\Cache
-            c:\hostedtoolcache\windows\python\*
           key: ${{ runner.os }}-build-${{ matrix.python-version }}
       - name: install-tox
         run: python -m pip install --upgrade tox virtualenv setuptools pip

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -18,6 +18,13 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Cache multiple paths
+        uses: actions/cache@v2
+        with:
+          path: |
+             ~/.cache/pip
+             ~\AppData\Local\pip\Cache
+          key: ${{ runner.os }}-${{ hashFiles('**lockfiles') }}
       - name: install-tox
         run: python -m pip install --upgrade tox virtualenv setuptools pip
       - name: install-reqs

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -22,10 +22,10 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-             ~/.cache/pip
-             /opt/hostedtoolcache/Python/
-             ~\AppData\Local\pip\Cache
-             c:\hostedtoolcache\windows\python\
+            ~/.cache/pip
+            /opt/hostedtoolcache/Python/
+            ~\AppData\Local\pip\Cache
+            c:\hostedtoolcache\windows\python\
           key: ${{ runner.os }}-build-${{ env.cache-name }}
       - name: install-tox
         run: python -m pip install --upgrade tox virtualenv setuptools pip


### PR DESCRIPTION
On the back of the issue #320 (and original issue #89) amending the following GitHub actions:

- [x] tox.yml  
- [x]  autoupdate-pre-commit-config.yml 
- [x] pre-commit.yml

Adding the cache action to these github actions via the github action `cache@v2`.