### PR TITLE
tox: removing redundant install deps in GH action

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -28,8 +28,6 @@ jobs:
           key: ${{ runner.os }}-build-${{ matrix.python-version }}
       - name: install-tox
         run: python -m pip install --upgrade tox virtualenv setuptools pip
-      - name: install-reqs
-        run: python -m pip install --upgrade -r requirements-dev.txt && python -m pip install --upgrade -r requirements.txt
       - name: run-tox
         run: tox -e py
       - name: Upload coverage to Codecov


### PR DESCRIPTION
On the back of the discussions in PR #322. Removing redundant install deps in GH action for tox, as it is already applied in tox.ini (deps section)

Let's discuss further if necessary and also see if the CI/CD sustains or is impacted - @girip11 as requested by you