### PR TITLE
Fix nbqa-doctest hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,10 @@ repos:
       - id: requirements-txt-fixer
       - id: trailing-whitespace
       - id: debug-statements
+  - repo: https://github.com/pre-commit/pre-commit
+    rev: v2.7.1
+    hooks:
+      - id: validate_manifest
   - repo: https://github.com/python/black
     rev: 20.8b1
     hooks:

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -17,7 +17,7 @@
   additional_dependencies: [black]
 - id: nbqa-mypy
   name: nbqa-mypy
-  description: "Run 'black' on a Jupyter Notebook"
+  description: "Run 'mypy' on a Jupyter Notebook"
   entry: nbqa mypy
   language: python
   language_version: python3
@@ -60,12 +60,3 @@
   require_serial: true
   types: [jupyter]
   additional_dependencies: [pylint]
-- id: nbqa-doctest
-  name: nbqa-doctest
-  description: "Run 'doctest' on a Jupyter Notebook"
-  entry: nbqa doctest
-  language: python
-  language_version: python3
-  require_serial: true
-  types: [jupyter]
-  additional_dependencies: [doctest]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -68,3 +68,4 @@
   language_version: python3
   require_serial: true
   types: [jupyter]
+  additional_dependencies: [doctest]


### PR DESCRIPTION
While testing #346, I found that the `nbqa-doctest` hook is broken, because `doctest` is missing in the hook env.

Reproducible with `pre-commit try-repo https://github.com/nbQA-dev/nbQA -a` at a folder with `*.ipynb` files.

- Added `additional_dependencies: [doctest]` to `nbqa-doctest` hook
- Added pre-commit parsing test for `.pre-commit-hooks.yaml`

closes #346 