### PR TITLE
Add extras_require, to install nbqa with all supported tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ Install `nbqa` in your [virtual environment](https://realpython.com/python-virtu
 python -m pip install -U nbqa
 ```
 
+If you want to install `nbqa` together with all tools it supports, you can do so by running:
+
+```bash
+python -m pip install -U nbqa[toolchain]
+```
+
 ## 🚀 Examples
 
 Reformat your notebooks with

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,10 @@ setup_requirements = []
 
 test_requirements = []
 
+extra_requirements = {
+    "toolchain": ["black", "mypy", "isort", "pyupgrade", "flake8", "pylint"]
+}
+
 setup(
     author="Marco Gorelli, Girish Pasupathy",
     python_requires=">=3.6",
@@ -40,6 +44,7 @@ setup(
     setup_requires=setup_requirements,
     test_suite="tests",
     tests_require=test_requirements,
+    extras_require=extra_requirements,
     url="https://github.com/nbQA-dev/nbQA",
     version="0.3.2",
     zip_safe=False,


### PR DESCRIPTION
This will allow users to install `nbqa` + all supported tools by running 
```console
$ python -m pip install -U nbqa[toolchain]
```

Maybe there is a better name than `toolchain` e.g. `full`, `all`, `tools` (maybe `+tools`, which has a nice readability)

closes #357 

