### PR TITLE
hard-code cell magics to ignore

### DIFF
--- a/nbqa/save_source.py
+++ b/nbqa/save_source.py
@@ -27,6 +27,7 @@ MAGIC = [
     "%%latex",
     "%%markdown",
     "%%perl",
+    "%%python2",
     "%%ruby",
     "%%script",
     "%%sh",

--- a/nbqa/save_source.py
+++ b/nbqa/save_source.py
@@ -18,7 +18,21 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 CODE_SEPARATOR = "# %%"
-MAGIC = ["%%script", "%%bash", "%%writefile", "%%cython"]
+MAGIC = [
+    "%%bash",
+    "%%cython",
+    "%%html",
+    "%%javascript",
+    "%%js",
+    "%%latex",
+    "%%markdown",
+    "%%perl",
+    "%%ruby",
+    "%%script",
+    "%%sh",
+    "%%svg",
+    "%%writefile",
+]
 NEWLINES = defaultdict(lambda: "\n\n")
 NEWLINES["isort"] = "\n"
 

--- a/nbqa/save_source.py
+++ b/nbqa/save_source.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 CODE_SEPARATOR = "# %%"
-MAGIC = ["%%script", "%%bash"]
+MAGIC = ["%%script", "%%bash", "%%writefile", "%%cython"]
 NEWLINES = defaultdict(lambda: "\n\n")
 NEWLINES["isort"] = "\n"
 


### PR DESCRIPTION
@girip11 with reference to #355

I see this as a temporary solution. Basically, on Friday, a new episode of the podcast Python Bytes will be out, and they said they'll mention our library.

My hope is that this will bring some new users here.

I don't think we can implement #355 in time, so my suggestion would be to, for now, hard-code all the magics from  https://ipython.readthedocs.io/en/stable/interactive/magics.html (so that any new user likely has a smooth user experience without having to learn about `--nbqa-ignore-cells`), and then once #355 is addressed properly we can deprecate `--nbqa-ignore-cells`.

@nbQA-dev/nbqa-core thoughts? Any objections?

----

I haven't added extra test cases as coverage isn't affected and we already have tests to check that cell magics listed in this constant are indeed ignored