### PR TITLE
Add tests for docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,35 @@
+name: docs
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  docs:
+    name: "Running: ${{ matrix.tox-env-name }}"
+    strategy:
+      matrix:
+        tox-env-name: ["docs", "docs-links"]
+
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.7 # Same as RTD
+      - name: Cache multiple paths
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: docs
+      - name: install-tox
+        run: python -m pip install --upgrade tox virtualenv setuptools pip
+      - name: run ${{ matrix.tox-env-name }}
+        run: tox -e ${{ matrix.tox-env-name }}
+      - name: Upload docs artifact
+        if: ${{ matrix.tox-env-name }} == "docs"
+        uses: actions/upload-artifact@v2
+        with:
+          name: nbqa-docs
+          path: docs/_build/html

--- a/docs/_templates/autosummary/attribute.rst
+++ b/docs/_templates/autosummary/attribute.rst
@@ -1,0 +1,4 @@
+{{ name  | escape | underline }}
+
+.. autoattribute:: {{ fullname }}
+    :noindex:

--- a/docs/_templates/autosummary/class.rst
+++ b/docs/_templates/autosummary/class.rst
@@ -1,0 +1,51 @@
+{{ objname | escape | underline}}
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}
+
+    {% block attributes_summary %}
+    {% if attributes %}
+
+    .. rubric:: Attributes Summary
+
+    .. autosummary::
+    {% for item in attributes %}
+            ~{{ item }}
+    {%- endfor %}
+
+    {% endif %}
+    {% endblock %}
+
+    {% block methods_summary %}
+    {% if methods %}
+
+    {% if '__init__' in methods %}
+        {% set caught_result = methods.remove('__init__') %}
+    {% endif %}
+
+    .. rubric:: Methods Summary
+
+    .. autosummary::
+        :toctree: {{ objname }}/methods
+        :nosignatures:
+
+    {% for item in methods %}
+        ~{{ name }}.{{ item }}
+    {%- endfor %}
+
+    {% endif %}
+    {% endblock %}
+
+    {% block methods_documentation %}
+    {% if methods %}
+
+    .. rubric:: Methods Documentation
+
+    {% for item in methods %}
+    .. automethod:: {{ name }}.{{ item }}
+        :noindex:
+    {%- endfor %}
+
+    {% endif %}
+    {% endblock %}

--- a/docs/_templates/autosummary/method.rst
+++ b/docs/_templates/autosummary/method.rst
@@ -1,0 +1,3 @@
+{{ name  | escape | underline }}
+
+.. automethod:: {{ fullname }}

--- a/docs/_templates/autosummary/module.rst
+++ b/docs/_templates/autosummary/module.rst
@@ -1,12 +1,97 @@
 {% block module %}
-{{ fullname | replace("nbqa.", "") | escape | underline}}
-{#{% set reduced_name={child_modules} %}#}
+{{ name  | escape | underline}}
 
 .. currentmodule:: {{ module }}
 
 .. automodule:: {{ fullname }}
-   :members:
-   :private-members:
-   :special-members:
+
+
+   {% block modules %}
+   {% if modules %}
+
+   .. rubric:: Modules
+
+   .. autosummary::
+      :toctree: {{ name }}
+      :recursive:
+
+      {% for item in modules %}
+         {{ item }}
+      {%- endfor %}
+
+   {% endif %}
+
+   {% endblock %}
+
+
+   {% block attributes %}
+   {% if attributes %}
+   .. rubric:: Module Attributes
+
+   .. autosummary::
+         :toctree: {{ name }}
+
+         {% for item in attributes %}
+            {{ item }}
+         {%- endfor %}
+
+   {% endif %}
+
+   {% endblock %}
+
+{% block functions %}
+   {% if functions %}
+
+
+   .. rubric:: Functions
+
+   .. autosummary::
+         :toctree: {{ name }}/functions
+         :nosignatures:
+
+         {% for item in functions %}
+         {{ item }}
+         {%- endfor %}
+
+   {% endif %}
+
+{% endblock %}
+
+{% block classes %}
+   {% if classes %}
+
+   .. rubric:: Classes
+
+   .. autosummary::
+         :toctree: {{ name }}/classes
+         :nosignatures:
+
+         {% for item in classes %}
+         {{ item }}
+         {%- endfor %}
+
+   {% endif %}
+
+{% endblock %}
+
+
+{% block exceptions %}
+   {% if exceptions %}
+
+
+   .. rubric:: Exceptions
+
+   .. autosummary::
+         :toctree: {{ name }}/exceptions
+         :nosignatures:
+
+         {% for item in exceptions %}
+            {{ item }}
+         {%- endfor %}
+
+   {% endif %}
+
+{% endblock %}
+
 
 {% endblock %}

--- a/docs/clean_build_artifacts.py
+++ b/docs/clean_build_artifacts.py
@@ -1,0 +1,14 @@
+"""Cross platform way to call 'rm -rf docs/_build/ docs/api/' """
+from pathlib import Path
+from shutil import rmtree
+
+
+def delete_artifacts():
+    """Delete API and _build directories"""
+    current_dir = Path(__file__).parent
+    rmtree(current_dir / "api", ignore_errors=True)
+    rmtree(current_dir / "_build", ignore_errors=True)
+
+
+if __name__ == "__main__":
+    delete_artifacts()

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,12 +17,8 @@
 # relative to the documentation root, use os.path.abspath to make it
 # absolute, like shown here.
 #
-import os
-import sys
 
-sys.path.insert(0, os.path.abspath(".."))
-
-import nbqa  # noqa
+import nbqa
 
 # -- General configuration ---------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -97,6 +97,9 @@ todo_include_todos = False
 # a list of builtin themes.
 #
 html_theme = "sphinx_rtd_theme"
+html_theme_options = {
+    "navigation_depth": -1,
+}
 
 # Theme options are theme-specific and customize the look and feel of a
 # theme further.  For a list of options available for each theme, see the

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -4,13 +4,9 @@ Inner workings
 
 This is the detailed documentation of the inner workings of ``nbqa``.
 
-.. currentmodule:: nbqa
-
 .. autosummary::
    :recursive:
    :nosignatures:
    :toctree: api/
 
-   __main__
-   replace_source
-   save_source
+   nbqa

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages, setup
 
 readme = Path("README.md").read_text(encoding="utf8")
 
-requirements = ["toml"]
+requirements = ["toml", "importlib_metadata; python_version < '3.8'"]
 
 setup_requirements = []
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,15 @@
 [tox]
-envlist = py36, py37, py38, py39
+envlist = py{36,37,38,39}, docs, docs-links
+
+[testenv:docs]
+deps = -rdocs/requirements-docs.txt
+commands =
+    {envpython} -m sphinx -W -b html docs docs/_build/html
+
+[testenv:docs-links]
+deps = -rdocs/requirements-docs.txt
+commands =
+    {envpython} -m sphinx -W -b linkcheck docs docs/_build/html
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,11 @@ deps = -rdocs/requirements-docs.txt
 commands =
     {envpython} -m sphinx -W -b linkcheck docs docs/_build/html
 
+[testenv:clean-docs]
+skip_install = true
+deps =
+commands = python {toxinidir}/docs/clean_build_artifacts.py
+
 [testenv]
 deps =
     -rrequirements-dev.txt


### PR DESCRIPTION
- Fixed broken `setup.py`, for python < 3.8
- Adds Workflow that tests
  - If the docs build
  - If there are broken links
  - Uploads an artifact of the built docs
- Adds 2 new tox tests with the same functionality (`docs`, `docs-links`)
- Adds tox env to clean docs built artifacts cross platform (there will be errors if locally there are old API files, e.g. if a function gets renamed/removed)
- Makes doc creation more flexible (no more hardcoded module names, but auto discovery from the root package)
- Private methods/functions (starting with `_`) aren't part of the docs anymore

closes #345 