### PR TITLE
Add autoflake hook, and more

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,7 @@ repos:
     rev: 3.8.4
     hooks:
       - id: flake8
+        additional_dependencies: [flake8-typing-imports==1.10.0]
   - repo: https://github.com/PyCQA/isort
     rev: 5.6.4
     hooks:
@@ -75,3 +76,12 @@ repos:
     rev: v1.15.1
     hooks:
       - id: setup-cfg-fmt
+  - repo: https://github.com/myint/autoflake
+    rev: v1.4
+    hooks:
+      - id: autoflake
+        args: [--remove-all-unused-imports, -i]
+  - repo: meta
+    hooks:
+      - id: check-hooks-apply
+      - id: check-useless-excludes

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ py_modules = nbqa
 install_requires =
     toml
     importlib_metadata;python_version < '3.8'
-python_requires = >=3.6
+python_requires = >=3.6.1
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
This was useful - I was wondering why pyupgrade was for Python>=3.6.1, but then running flake8 with this extension revealed
```
nbqa/config/config.py:15:5: TYP005 NamedTuple does not support defaults in 3.6.0
```