### PR TITLE
Added some more missing cell magics to ignore by default.

### DIFF
--- a/nbqa/save_source.py
+++ b/nbqa/save_source.py
@@ -19,8 +19,10 @@ if TYPE_CHECKING:
 
 CODE_SEPARATOR = "# %%"
 MAGIC = [
+    "%%!",
     "%%bash",
     "%%cython",
+    "%%HTML",
     "%%html",
     "%%javascript",
     "%%js",
@@ -31,6 +33,9 @@ MAGIC = [
     "%%ruby",
     "%%script",
     "%%sh",
+    "%%sx",
+    "%%system",
+    "%%SVG",
     "%%svg",
     "%%writefile",
 ]


### PR DESCRIPTION
Got the list of cell magics by running `%lsmagic` from inside jupyter notebook

Changes to be committed:
	modified:   nbqa/save_source.py