### PR TITLE
Use universal_newlines=True

### DIFF
--- a/nbqa/__main__.py
+++ b/nbqa/__main__.py
@@ -398,14 +398,15 @@ def _run_command(
         stdout=subprocess.PIPE,
         cwd=tmpdirname,
         env=env,
+        text=True,
     )
 
     mutated = [_get_mtimes(i) for i in args] != before
 
     output_code = output.returncode
 
-    out = output.stdout.decode()
-    err = output.stderr.decode()
+    out = output.stdout
+    err = output.stderr
 
     return out, err, output_code, mutated
 

--- a/nbqa/__main__.py
+++ b/nbqa/__main__.py
@@ -398,7 +398,7 @@ def _run_command(
         stdout=subprocess.PIPE,
         cwd=tmpdirname,
         env=env,
-        text=True,
+        universal_newlines=True,  # from Python3.7 this can be replaced with `text`
     )
 
     mutated = [_get_mtimes(i) for i in args] != before

--- a/nbqa/__main__.py
+++ b/nbqa/__main__.py
@@ -507,7 +507,7 @@ def _run_on_one_root_dir(
         if not nb_to_py_mapping:
             sys.stderr.write(
                 "No .ipynb notebooks found in given directories: "
-                f"{' '.join(i for i in cli_args.root_dirs if Path(i).is_dir())}{os.linesep}"
+                f"{' '.join(i for i in cli_args.root_dirs if Path(i).is_dir())}\n"
             )
             return 0
 

--- a/tests/test_ipython_magics.py
+++ b/tests/test_ipython_magics.py
@@ -1,6 +1,5 @@
 """Check user can check for other magics."""
 import json
-import os
 from pathlib import Path
 from shutil import copyfile
 from typing import TYPE_CHECKING, Callable, List, Optional, Tuple
@@ -31,7 +30,7 @@ def _validate_ignore_cells_with_warning(actual: str, test_nb_path: Path) -> bool
     expected_out = [
         "cell_2:3:1: F401 'glob' imported but unused",
     ]
-    expected = "".join(f"{str(test_nb_path)}:{i}{os.linesep}" for i in expected_out)
+    expected = "".join(f"{str(test_nb_path)}:{i}\n" for i in expected_out)
     return expected == actual
 
 

--- a/tests/test_runtime_errors.py
+++ b/tests/test_runtime_errors.py
@@ -122,7 +122,7 @@ def test_unable_to_parse_output(capsys: "CaptureFixture") -> None:
         """  # noqa: E501
     )
     # pylint: enable=C0301
-    expected_out = f"{str(path)}:6174:0 some silly warning{os.linesep}"
+    expected_out = f"{str(path)}:6174:0 some silly warning\n"
     with pytest.raises(SystemExit):
         main(["print_6174", str(path), "--nbqa-mutate"])
     out, err = capsys.readouterr()
@@ -142,4 +142,4 @@ def test_directory_without_notebooks(capsys: "CaptureFixture"):
     with pytest.raises(SystemExit):
         main(["black", "docs"])
     _, err = capsys.readouterr()
-    assert f"No .ipynb notebooks found in given directories: docs{os.linesep}" == err
+    assert "No .ipynb notebooks found in given directories: docs\n" == err

--- a/tests/tools/test_black.py
+++ b/tests/tools/test_black.py
@@ -53,13 +53,15 @@ def test_black_works(tmp_notebook_for_testing: Path, capsys: "CaptureFixture") -
 
     diff = difflib.unified_diff(before, after)
     result = "".join([i for i in diff if any([i.startswith("+ "), i.startswith("- ")])])
-    expected = (
-        "-    \"    return 'hello {}'.format(name)\\n\",\n"
-        '+    "    return \\"hello {}\\".format(name)\\n",\n'
-        '-    "hello(3)   "\n'
-        '+    "hello(3)"\n'
-        '-    "    %time randint(5,10)"\n'
-        '+    "    %time randint(5, 10)"\n'
+    expected = dedent(
+        """\
+            -    \"    return 'hello {}'.format(name)\\n\",
+            +    "    return \\"hello {}\\".format(name)\\n",
+            -    "hello(3)   "
+            +    "hello(3)"
+            -    "    %time randint(5,10)"
+            +    "    %time randint(5, 10)"
+            """
     )
     assert result == expected
 
@@ -121,16 +123,18 @@ def test_black_works_with_trailing_semicolons(
 
     diff = difflib.unified_diff(before, after)
     result = "".join([i for i in diff if any([i.startswith("+ "), i.startswith("- ")])])
-    expected = (
-        '-    "import glob;\\n",\n'
-        '+    "import glob\\n",\n'
-        '-    "def func(a, b):\\n",\n'
-        '-    "    pass;\\n",\n'
-        '-    " "\n'
-        '+    "def func(\\n",\n'
-        '+    "    a, b\\n",\n'
-        '+    "):\\n",\n'
-        '+    "    pass;"\n'
+    expected = dedent(
+        """\
+            -    "import glob;\\n",
+            +    "import glob\\n",
+            -    "def func(a, b):\\n",
+            -    "    pass;\\n",
+            -    " "
+            +    "def func(\\n",
+            +    "    a, b\\n",
+            +    "):\\n",
+            +    "    pass;"
+            """
     )
     assert result == expected
 
@@ -141,10 +145,10 @@ def test_black_works_with_trailing_semicolons(
     expected_err = (
         dedent(
             f"""\
-            reformatted {path}
-            All done! {SPARKLES} {SHORTCAKE} {SPARKLES}
-            1 file reformatted.
-            """
+        reformatted {path}
+        All done! {SPARKLES} {SHORTCAKE} {SPARKLES}
+        1 file reformatted.
+        """
         )
         .encode("ascii", "backslashreplace")
         .decode()
@@ -192,10 +196,12 @@ def test_black_works_with_multiline(
 
     diff = difflib.unified_diff(before, after)
     result = "".join([i for i in diff if any([i.startswith("+ "), i.startswith("- ")])])
-    expected = (
-        '-    "assert 1 + 1 == 2;  assert 1 + 1 == 2;"\n'
-        '+    "assert 1 + 1 == 2\\n",\n'
-        '+    "assert 1 + 1 == 2;"\n'
+    expected = dedent(
+        """\
+            -    "assert 1 + 1 == 2;  assert 1 + 1 == 2;"
+            +    "assert 1 + 1 == 2\\n",
+            +    "assert 1 + 1 == 2;"
+            """
     )
     assert result == expected
 

--- a/tests/tools/test_black.py
+++ b/tests/tools/test_black.py
@@ -69,9 +69,9 @@ def test_black_works(tmp_notebook_for_testing: Path, capsys: "CaptureFixture") -
     # replace \u with \\u for both expected_err and err
     expected_err = (
         (
-            f"reformatted {path}{os.linesep}"
-            f"All done! {SPARKLES} {SHORTCAKE} {SPARKLES}{os.linesep}"
-            f"1 file reformatted.{os.linesep}"
+            f"reformatted {path}\n"
+            f"All done! {SPARKLES} {SHORTCAKE} {SPARKLES}\n"
+            f"1 file reformatted.\n"
         )
         .encode("ascii", "backslashreplace")
         .decode()
@@ -138,9 +138,9 @@ def test_black_works_with_trailing_semicolons(
     # replace \u with \\u for both expected_err and err
     expected_err = (
         (
-            f"reformatted {path}{os.linesep}"
-            f"All done! {SPARKLES} {SHORTCAKE} {SPARKLES}{os.linesep}"
-            f"1 file reformatted.{os.linesep}"
+            f"reformatted {path}\n"
+            f"All done! {SPARKLES} {SHORTCAKE} {SPARKLES}\n"
+            f"1 file reformatted.\n"
         )
         .encode("ascii", "backslashreplace")
         .decode()
@@ -201,9 +201,9 @@ def test_black_works_with_multiline(
     # replace \u with \\u for both expected_err and err
     expected_err = (
         (
-            f"reformatted {path}{os.linesep}"
-            f"All done! {SPARKLES} {SHORTCAKE} {SPARKLES}{os.linesep}"
-            f"1 file reformatted.{os.linesep}"
+            f"reformatted {path}\n"
+            f"All done! {SPARKLES} {SHORTCAKE} {SPARKLES}\n"
+            f"1 file reformatted.\n"
         )
         .encode("ascii", "backslashreplace")
         .decode()

--- a/tests/tools/test_black.py
+++ b/tests/tools/test_black.py
@@ -68,17 +68,10 @@ def test_black_works(tmp_notebook_for_testing: Path, capsys: "CaptureFixture") -
     expected_out = ""
     # replace \u with \\u for both expected_err and err
     expected_err = (
-        (
-            f"reformatted {path}\n"
-            f"All done! {SPARKLES} {SHORTCAKE} {SPARKLES}\n"
-            f"1 file reformatted.\n"
-        )
-        .encode("ascii", "backslashreplace")
-        .decode()
+        f"reformatted {path}\n"
+        f"All done! {SPARKLES} {SHORTCAKE} {SPARKLES}\n"
+        f"1 file reformatted.\n"
     )
-    # This is required because linux supports emojis
-    # so both should have \\ for comparison
-    err = err.encode("ascii", "backslashreplace").decode()
     assert out == expected_out
     assert expected_err == err
 

--- a/tests/tools/test_black.py
+++ b/tests/tools/test_black.py
@@ -55,13 +55,13 @@ def test_black_works(tmp_notebook_for_testing: Path, capsys: "CaptureFixture") -
     result = "".join([i for i in diff if any([i.startswith("+ "), i.startswith("- ")])])
     expected = dedent(
         """\
-            -    \"    return 'hello {}'.format(name)\\n\",
-            +    "    return \\"hello {}\\".format(name)\\n",
-            -    "hello(3)   "
-            +    "hello(3)"
-            -    "    %time randint(5,10)"
-            +    "    %time randint(5, 10)"
-            """
+        -    \"    return 'hello {}'.format(name)\\n\",
+        +    "    return \\"hello {}\\".format(name)\\n",
+        -    "hello(3)   "
+        +    "hello(3)"
+        -    "    %time randint(5,10)"
+        +    "    %time randint(5, 10)"
+        """
     )
     assert result == expected
 
@@ -125,16 +125,16 @@ def test_black_works_with_trailing_semicolons(
     result = "".join([i for i in diff if any([i.startswith("+ "), i.startswith("- ")])])
     expected = dedent(
         """\
-            -    "import glob;\\n",
-            +    "import glob\\n",
-            -    "def func(a, b):\\n",
-            -    "    pass;\\n",
-            -    " "
-            +    "def func(\\n",
-            +    "    a, b\\n",
-            +    "):\\n",
-            +    "    pass;"
-            """
+        -    "import glob;\\n",
+        +    "import glob\\n",
+        -    "def func(a, b):\\n",
+        -    "    pass;\\n",
+        -    " "
+        +    "def func(\\n",
+        +    "    a, b\\n",
+        +    "):\\n",
+        +    "    pass;"
+        """
     )
     assert result == expected
 
@@ -145,10 +145,10 @@ def test_black_works_with_trailing_semicolons(
     expected_err = (
         dedent(
             f"""\
-        reformatted {path}
-        All done! {SPARKLES} {SHORTCAKE} {SPARKLES}
-        1 file reformatted.
-        """
+            reformatted {path}
+            All done! {SPARKLES} {SHORTCAKE} {SPARKLES}
+            1 file reformatted.
+            """
         )
         .encode("ascii", "backslashreplace")
         .decode()
@@ -198,10 +198,10 @@ def test_black_works_with_multiline(
     result = "".join([i for i in diff if any([i.startswith("+ "), i.startswith("- ")])])
     expected = dedent(
         """\
-            -    "assert 1 + 1 == 2;  assert 1 + 1 == 2;"
-            +    "assert 1 + 1 == 2\\n",
-            +    "assert 1 + 1 == 2;"
-            """
+        -    "assert 1 + 1 == 2;  assert 1 + 1 == 2;"
+        +    "assert 1 + 1 == 2\\n",
+        +    "assert 1 + 1 == 2;"
+        """
     )
     assert result == expected
 

--- a/tests/tools/test_black.py
+++ b/tests/tools/test_black.py
@@ -68,10 +68,19 @@ def test_black_works(tmp_notebook_for_testing: Path, capsys: "CaptureFixture") -
     expected_out = ""
     # replace \u with \\u for both expected_err and err
     expected_err = (
-        f"reformatted {path}\n"
-        f"All done! {SPARKLES} {SHORTCAKE} {SPARKLES}\n"
-        f"1 file reformatted.\n"
+        dedent(
+            f"""\
+            reformatted {path}
+            All done! {SPARKLES} {SHORTCAKE} {SPARKLES}
+            1 file reformatted.
+            """
+        )
+        .encode("ascii", "backslashreplace")
+        .decode()
     )
+    # This is required because linux supports emojis
+    # so both should have \\ for comparison
+    err = err.encode("ascii", "backslashreplace").decode()
     assert out == expected_out
     assert expected_err == err
 
@@ -130,10 +139,12 @@ def test_black_works_with_trailing_semicolons(
     expected_out = ""
     # replace \u with \\u for both expected_err and err
     expected_err = (
-        (
-            f"reformatted {path}\n"
-            f"All done! {SPARKLES} {SHORTCAKE} {SPARKLES}\n"
-            f"1 file reformatted.\n"
+        dedent(
+            f"""\
+            reformatted {path}
+            All done! {SPARKLES} {SHORTCAKE} {SPARKLES}
+            1 file reformatted.
+            """
         )
         .encode("ascii", "backslashreplace")
         .decode()
@@ -193,10 +204,12 @@ def test_black_works_with_multiline(
     expected_out = ""
     # replace \u with \\u for both expected_err and err
     expected_err = (
-        (
-            f"reformatted {path}\n"
-            f"All done! {SPARKLES} {SHORTCAKE} {SPARKLES}\n"
-            f"1 file reformatted.\n"
+        dedent(
+            f"""\
+            reformatted {path}
+            All done! {SPARKLES} {SHORTCAKE} {SPARKLES}
+            1 file reformatted.
+            """
         )
         .encode("ascii", "backslashreplace")
         .decode()

--- a/tests/tools/test_isort_works.py
+++ b/tests/tools/test_isort_works.py
@@ -39,10 +39,10 @@ def test_isort_works(tmp_notebook_for_testing: Path, capsys: "CaptureFixture") -
     result = "".join([i for i in diff if any([i.startswith("+ "), i.startswith("- ")])])
     expected = dedent(
         """\
-            +    "import glob\\n",
-            -    "\\n",
-            -    "import glob\\n",
-            """
+        +    "import glob\\n",
+        -    "\\n",
+        -    "import glob\\n",
+        """
     )
     assert result == expected
 
@@ -80,10 +80,10 @@ def test_isort_initial_md(
     result = "".join([i for i in diff if any([i.startswith("+ "), i.startswith("- ")])])
     expected = dedent(
         """\
-            +    "import glob\\n",
-            -    "\\n",
-            -    "import glob\\n",
-            """
+        +    "import glob\\n",
+        -    "\\n",
+        -    "import glob\\n",
+        """
     )
     assert result == expected
 
@@ -162,12 +162,12 @@ def test_isort_trailing_semicolon(tmp_notebook_with_trailing_semicolon: Path) ->
     result = "".join([i for i in diff if any([i.startswith("+ "), i.startswith("- ")])])
     expected = dedent(
         """\
-            -    "import glob;\\n",
-            +    "import glob\\n",
-            -    "    pass;\\n",
-            -    " "
-            +    "    pass;"
-            """
+        -    "import glob;\\n",
+        +    "import glob\\n",
+        -    "    pass;\\n",
+        -    " "
+        +    "    pass;"
+        """
     )
     assert result == expected
 

--- a/tests/tools/test_isort_works.py
+++ b/tests/tools/test_isort_works.py
@@ -42,7 +42,7 @@ def test_isort_works(tmp_notebook_for_testing: Path, capsys: "CaptureFixture") -
 
     # check out and err
     out, err = capsys.readouterr()
-    expected_out = f"Fixing {path}{os.linesep}"
+    expected_out = f"Fixing {path}\n"
     expected_err = ""
     assert out == expected_out
     assert err == expected_err
@@ -77,7 +77,7 @@ def test_isort_initial_md(
 
     # check out and err
     out, err = capsys.readouterr()
-    expected_out = f"Fixing {path}{os.linesep}"
+    expected_out = f"Fixing {path}\n"
     expected_err = ""
     assert out == expected_out
     assert err == expected_err

--- a/tests/tools/test_isort_works.py
+++ b/tests/tools/test_isort_works.py
@@ -37,7 +37,13 @@ def test_isort_works(tmp_notebook_for_testing: Path, capsys: "CaptureFixture") -
         after = handle.readlines()
     diff = difflib.unified_diff(before, after)
     result = "".join([i for i in diff if any([i.startswith("+ "), i.startswith("- ")])])
-    expected = '+    "import glob\\n",\n-    "\\n",\n-    "import glob\\n",\n'
+    expected = dedent(
+        """\
+            +    "import glob\\n",
+            -    "\\n",
+            -    "import glob\\n",
+            """
+    )
     assert result == expected
 
     # check out and err
@@ -72,7 +78,13 @@ def test_isort_initial_md(
         after = handle.readlines()
     diff = difflib.unified_diff(before, after)
     result = "".join([i for i in diff if any([i.startswith("+ "), i.startswith("- ")])])
-    expected = '+    "import glob\\n",\n-    "\\n",\n-    "import glob\\n",\n'
+    expected = dedent(
+        """\
+            +    "import glob\\n",
+            -    "\\n",
+            -    "import glob\\n",
+            """
+    )
     assert result == expected
 
     # check out and err
@@ -148,12 +160,14 @@ def test_isort_trailing_semicolon(tmp_notebook_with_trailing_semicolon: Path) ->
         after = handle.readlines()
     diff = difflib.unified_diff(before, after)
     result = "".join([i for i in diff if any([i.startswith("+ "), i.startswith("- ")])])
-    expected = (
-        '-    "import glob;\\n",\n'
-        '+    "import glob\\n",\n'
-        '-    "    pass;\\n",\n'
-        '-    " "\n'
-        '+    "    pass;"\n'
+    expected = dedent(
+        """\
+            -    "import glob;\\n",
+            +    "import glob\\n",
+            -    "    pass;\\n",
+            -    " "
+            +    "    pass;"
+            """
     )
     assert result == expected
 

--- a/tests/tools/test_pyupgrade.py
+++ b/tests/tools/test_pyupgrade.py
@@ -50,9 +50,11 @@ def test_pyupgrade(tmp_notebook_for_testing: Path, capsys: "CaptureFixture") -> 
 
     diff = difflib.unified_diff(before, after)
     result = "".join([i for i in diff if any([i.startswith("+ "), i.startswith("- ")])])
-    expected = (
-        "-    \"    return 'hello {}'.format(name)\\n\",\n"
-        "+    \"    return f'hello {name}'\\n\",\n"
+    expected = dedent(
+        """\
+            -    \"    return 'hello {}'.format(name)\\n\",
+            +    \"    return f'hello {name}'\\n\",
+            """
     )
     assert result == expected
 

--- a/tests/tools/test_pyupgrade.py
+++ b/tests/tools/test_pyupgrade.py
@@ -59,6 +59,6 @@ def test_pyupgrade(tmp_notebook_for_testing: Path, capsys: "CaptureFixture") -> 
     # check out and err
     out, err = capsys.readouterr()
     expected_out = ""
-    expected_err = f"Rewriting {path}{os.linesep}"
+    expected_err = f"Rewriting {path}\n"
     assert out == expected_out
     assert err == expected_err

--- a/tests/tools/test_pyupgrade.py
+++ b/tests/tools/test_pyupgrade.py
@@ -52,9 +52,9 @@ def test_pyupgrade(tmp_notebook_for_testing: Path, capsys: "CaptureFixture") -> 
     result = "".join([i for i in diff if any([i.startswith("+ "), i.startswith("- ")])])
     expected = dedent(
         """\
-            -    \"    return 'hello {}'.format(name)\\n\",
-            +    \"    return f'hello {name}'\\n\",
-            """
+        -    \"    return 'hello {}'.format(name)\\n\",
+        +    \"    return f'hello {name}'\\n\",
+        """
     )
     assert result == expected
 


### PR DESCRIPTION
If this works it could simplify things.

Also, I think the current behaviour isn't quite right on Windows, as it adds extra newlines if you do e.g.
```
nbqa flake8 tests > out.txt
```
even though it looks fine when printing to the console.

Like this (with universal_newlines=True) then it looks correct on Windows both on the console, and when piping to a text file. Behaviour on Linux is unchanged.

This is great as it means we can simplify quite a few tests!

----

Just to clarify what I mean:

If I run
```
black tests --check 2> out.txt
```
then in `out.txt` I see:
```
would reformat C:\Users\m.gorelli.CORP\nbQA-dev\tests\test_find_root.py
would reformat C:\Users\m.gorelli.CORP\nbQA-dev\tests\test_ipython_magics.py
Oh no! \U0001f4a5 \U0001f494 \U0001f4a5
2 files would be reformatted, 26 files would be left unchanged.
```

However, if I write a script `subprocessrun.py` with
```python
import sys
import subprocess

output = subprocess.run(['black', 'tests', '--check'], stderr=subprocess.PIPE)
sys.stderr.write(output.stderr.decode())
```
and then run
```
python subprocessrun.py 2> out.txt
```
then in `out.txt` I see
```
would reformat C:\Users\m.gorelli.CORP\nbQA-dev\tests\test_find_root.py

would reformat C:\Users\m.gorelli.CORP\nbQA-dev\tests\test_ipython_magics.py

Oh no! \U0001f4a5 \U0001f494 \U0001f4a5

2 files would be reformatted, 26 files would be left unchanged.

```

If I change the Python script to
```
import sys
import subprocess

output = subprocess.run(['black', 'tests', '--check'], stderr=subprocess.PIPE, universal_newlines=True)
sys.stderr.write(output.stderr)
```
then `out.txt` looks correct:
```
would reformat C:\Users\m.gorelli.CORP\nbQA-dev\tests\test_find_root.py
would reformat C:\Users\m.gorelli.CORP\nbQA-dev\tests\test_ipython_magics.py
Oh no! \U0001f4a5 \U0001f494 \U0001f4a5
2 files would be reformatted, 26 files would be left unchanged.
```