### PR TITLE
remove config from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,10 +98,6 @@ Here's an example of how to set up some pre-commit hooks:
 for details)
 
    ```toml
-   [tool.nbqa.config]
-   isort = "setup.cfg"
-   black = "pyproject.toml"
-
    [tool.nbqa.mutate]
    isort = 1
    black = 1

--- a/docs/known-limitations.rst
+++ b/docs/known-limitations.rst
@@ -32,33 +32,3 @@ the trailing semicolon will be preserved:
 
     # some comment
     plt.plot();
-
-flake8 (and other linters)
---------------------------
-
-Line magics
-~~~~~~~~~~~
-
-If you import a module and then *only* use it in a line magic, then you may get an "unused import"
-warning from ``flake8``.
-
-Example:
-
-.. code:: python
-
-    # cell 1
-    import numpy as np
-
-    # cell 2
-    %time np.random.randn(1000)
-
-You can overcome this limitation by using a cell magic to time execution:
-
-.. code:: python
-
-    # cell 1
-    import numpy as np
-
-    # cell 2
-    %%time
-    np.random.randn(1000)


### PR DESCRIPTION
The configs here are no longer necessary, so IMO we should only mention them in the docs as they only apply to anyone using nbqa for a custom tool not officially supported. It risks being confusing