### PR TITLE
remove nbconvert

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,6 @@ packages = find:
 py_modules = nbqa
 install_requires =
     ipython>=7.8.0
-    nbconvert>=6.0.0
     toml
     importlib_metadata;python_version < '3.8'
 python_requires = >=3.6.1


### PR DESCRIPTION
It seems that the only place we use nbconvert is to call an IPython function. So, can we get rid of this requirement and just call IPython directly?