### PR TITLE
Fix test_unable_to_reconstruct_message_pythonpath

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,4 +7,5 @@ mypy
 pre-commit-hooks
 pylint
 pytest
+pytest-randomly
 pyupgrade

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 """Define some fixtures that can be re-used between tests."""
 
 import shutil
+import sys
 from distutils.dir_util import copy_tree  # pylint: disable=E0611
 from pathlib import Path
 from typing import TYPE_CHECKING, Iterator
@@ -186,6 +187,7 @@ def tmp_remove_comments() -> Iterator[None]:
     shutil.copy(str(Path("tests") / temp_file), str(temp_file))
     yield
     temp_file.unlink()
+    del sys.modules["remove_comments"]
 
 
 @pytest.fixture

--- a/tests/test_runtime_errors.py
+++ b/tests/test_runtime_errors.py
@@ -2,7 +2,6 @@
 
 import os
 import re
-import sys
 from pathlib import Path
 from textwrap import dedent
 from typing import TYPE_CHECKING
@@ -95,7 +94,6 @@ def test_unable_to_reconstruct_message_pythonpath(monkeypatch: "MonkeyPatch") ->
     path = os.path.abspath(os.path.join("tests", "data", "notebook_for_testing.ipynb"))
     message = re.escape(f"Error reconstructing {path}")
     monkeypatch.setenv("PYTHONPATH", os.path.join(os.getcwd(), "tests"))
-    monkeypatch.setattr("sys.path", sys.path + [os.path.join(os.getcwd(), "tests")])
     with pytest.raises(RuntimeError, match=message):
         main(["remove_comments", path, "--nbqa-mutate"])
 

--- a/tests/test_runtime_errors.py
+++ b/tests/test_runtime_errors.py
@@ -2,6 +2,7 @@
 
 import os
 import re
+import sys
 from pathlib import Path
 from textwrap import dedent
 from typing import TYPE_CHECKING
@@ -94,9 +95,9 @@ def test_unable_to_reconstruct_message_pythonpath(monkeypatch: "MonkeyPatch") ->
     path = os.path.abspath(os.path.join("tests", "data", "notebook_for_testing.ipynb"))
     message = f"Error reconstructing {path}"
     monkeypatch.setenv("PYTHONPATH", os.path.join(os.getcwd(), "tests"))
-    with pytest.raises(RuntimeError) as excinfo:
+    monkeypatch.setattr("sys.path", sys.path + [os.path.join(os.getcwd(), "tests")])
+    with pytest.raises(RuntimeError, match=message):
         main(["remove_comments", path, "--nbqa-mutate"])
-    assert message in str(excinfo.value)
 
 
 def test_unable_to_parse() -> None:

--- a/tests/test_runtime_errors.py
+++ b/tests/test_runtime_errors.py
@@ -93,7 +93,7 @@ def test_unable_to_reconstruct_message_pythonpath(monkeypatch: "MonkeyPatch") ->
         Pytest fixture, we use it to override ``PYTHONPATH``.
     """
     path = os.path.abspath(os.path.join("tests", "data", "notebook_for_testing.ipynb"))
-    message = f"Error reconstructing {path}"
+    message = re.escape(f"Error reconstructing {path}")
     monkeypatch.setenv("PYTHONPATH", os.path.join(os.getcwd(), "tests"))
     monkeypatch.setattr("sys.path", sys.path + [os.path.join(os.getcwd(), "tests")])
     with pytest.raises(RuntimeError, match=message):


### PR DESCRIPTION
closes #473 

The current changes ensure that the test passes when it's run by itself. Without monkeypatching `sys.path`, then the `import_module` part fails during the test run.

I haven't figured out which test, if run before this one, makes this one pass, but it's probably worth investigating