### PR TITLE
fix: UnicodeDecodeError

### DIFF
--- a/nbqa/replace_source.py
+++ b/nbqa/replace_source.py
@@ -157,7 +157,7 @@ def mutate(python_file: "Path", notebook: "Path", notebook_info: NotebookInfo) -
     notebook_info
         Information about notebook cells used for processing
     """
-    notebook_json = json.loads(notebook.read_text())
+    notebook_json = json.loads(notebook.read_text(encoding="utf-8"))
 
     pycells = _get_pycells(python_file)
     for code_cell_number, cell in enumerate(
@@ -167,7 +167,7 @@ def mutate(python_file: "Path", notebook: "Path", notebook_info: NotebookInfo) -
             continue
         cell["source"] = _get_new_source(code_cell_number, notebook_info, next(pycells))
 
-    notebook.write_text(f"{json.dumps(notebook_json, indent=1, ensure_ascii=False)}\n")
+    notebook.write_text(f"{json.dumps(notebook_json, indent=1, ensure_ascii=False)}\n", encoding="utf-8")
 
 
 def _print_diff(code_cell_number: int, cell_diff: Iterator[str]) -> None:
@@ -211,7 +211,7 @@ def diff(python_file: "Path", notebook: "Path", notebook_info: NotebookInfo) -> 
     notebook_info
         Information about notebook cells used for processing
     """
-    notebook_json = json.loads(notebook.read_text())
+    notebook_json = json.loads(notebook.read_text(encoding="utf-8"))
 
     pycells = _get_pycells(python_file)
 

--- a/nbqa/replace_source.py
+++ b/nbqa/replace_source.py
@@ -167,7 +167,9 @@ def mutate(python_file: "Path", notebook: "Path", notebook_info: NotebookInfo) -
             continue
         cell["source"] = _get_new_source(code_cell_number, notebook_info, next(pycells))
 
-    notebook.write_text(f"{json.dumps(notebook_json, indent=1, ensure_ascii=False)}\n", encoding="utf-8")
+    notebook.write_text(
+        f"{json.dumps(notebook_json, indent=1, ensure_ascii=False)}\n", encoding="utf-8"
+    )
 
 
 def _print_diff(code_cell_number: int, cell_diff: Iterator[str]) -> None:

--- a/nbqa/save_source.py
+++ b/nbqa/save_source.py
@@ -366,7 +366,9 @@ def main(
             result.append(re.sub(r";(\s*)$", "\\1", parsed_cell))
             line_number += len(parsed_cell.splitlines())
 
-    temp_python_file.write_text("".join(result).rstrip(NEWLINE) + NEWLINE, encoding="utf-8")
+    temp_python_file.write_text(
+        "".join(result).rstrip(NEWLINE) + NEWLINE, encoding="utf-8"
+    )
 
     return NotebookInfo(
         cell_mapping, trailing_semicolons, temporary_lines, code_cells_to_ignore

--- a/nbqa/save_source.py
+++ b/nbqa/save_source.py
@@ -331,7 +331,7 @@ def main(
     NotebookInfo
 
     """
-    cells = json.loads(notebook.read_text())["cells"]
+    cells = json.loads(notebook.read_text(encoding="utf-8"))["cells"]
 
     result = []
     cell_mapping = {0: "cell_0:0"}
@@ -366,7 +366,7 @@ def main(
             result.append(re.sub(r";(\s*)$", "\\1", parsed_cell))
             line_number += len(parsed_cell.splitlines())
 
-    temp_python_file.write_text("".join(result).rstrip(NEWLINE) + NEWLINE)
+    temp_python_file.write_text("".join(result).rstrip(NEWLINE) + NEWLINE, encoding="utf-8")
 
     return NotebookInfo(
         cell_mapping, trailing_semicolons, temporary_lines, code_cells_to_ignore


### PR DESCRIPTION
nbQA helps us to keep notebooks to the same standards as the rest of the code. If you're serious about your code standards, you should keep them consistent across both notebooks and python scripts. Great addition to the ecosystem, thanks!

Version nbQA 0.5.1 throws an UnicodeDecodeError exception on my Windows machine. The proposed changes in this PR resolve it for my configuration, however I could imagine it's desirable to configure/automatically detect the charset for more general usage.

Find the updated configuration of how we use nbQA in pandas-profiling here: https://github.com/pandas-profiling/pandas-profiling/pull/628