### PR TITLE
Remove 'bdist_wheel universal=True' since the package is Python 3.6.1+

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -59,9 +59,6 @@ nbqa =
 exclude =
     tests*
 
-[bdist_wheel]
-universal = True
-
 [flake8]
 extend-ignore = E203,E503
 max-line-length = 120


### PR DESCRIPTION
This is just a minor cleanup for the [filename of the generated wheel](https://pypi.org/project/nbqa/0.5.7/#files), which includes `py2` and might confuse users.