### PR TITLE
Make mutations atomic

### DIFF
--- a/nbqa/replace_source.py
+++ b/nbqa/replace_source.py
@@ -7,6 +7,7 @@ The converted file will have had the third-party tool run against it by now.
 import json
 import sys
 from difflib import unified_diff
+from shutil import move
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -178,9 +179,11 @@ def mutate(python_file: "Path", notebook: "Path", notebook_info: NotebookInfo) -
             continue
         cell["source"] = _get_new_source(code_cell_number, notebook_info, next(pycells))
 
-    notebook.write_text(
+    temp_notebook = python_file.parent / notebook.name
+    temp_notebook.write_text(
         f"{json.dumps(notebook_json, indent=1, ensure_ascii=False)}\n", encoding="utf-8"
     )
+    move(str(temp_notebook), str(notebook))
 
 
 def _print_diff(code_cell_number: int, cell_diff: Iterator[str]) -> None:


### PR DESCRIPTION
Depending on how many cells and plots a notebook has it can be quite big, thus writing mutations may take some time.
If writing the mutations gets interrupted for some reason (e.g. `KeyboardInterrupt`) this might corrupt the notebook.
In the best-case scenario, the user just loses uncommitted changes, and in the worst-case, their whole work is gone.

Thus writing the changes to a temp file and overwriting the original by a simple `move` reduces the risk of data corruption.

Note that I used `shutil.move()` instead of `Path.rename()` [because `move` also works if the temp and original file are on different drives](https://stackoverflow.com/a/16845955/3990615).

And ofc Anthony  also has a video on this 😋 
[![what is atomicity (intermediate) anthony explains #168](http://img.youtube.com/vi/tmlmCG5egI0/0.jpg)](https://www.youtube.com/watch?v=tmlmCG5egI0 "what is atomicity (intermediate) anthony explains #168")