### PR TITLE
No diff if error

### DIFF
--- a/nbqa/__main__.py
+++ b/nbqa/__main__.py
@@ -621,15 +621,15 @@ def _run_on_one_root_dir(
                         )
                     ) from exc
 
+        sys.stdout.write(out)
+        sys.stderr.write(err)
+
         if configs.nbqa_diff:
             if mutated:
                 sys.stdout.write(
                     "To apply these changes use `--nbqa-mutate` instead of `--nbqa-diff`\n"
                 )
-            return 0
-
-        sys.stdout.write(out)
-        sys.stderr.write(err)
+            return output_code
 
     return output_code
 

--- a/tests/test_nbqa_diff.py
+++ b/tests/test_nbqa_diff.py
@@ -3,6 +3,7 @@
 import os
 import re
 from pathlib import Path
+from textwrap import dedent
 from typing import TYPE_CHECKING
 
 import pytest
@@ -29,6 +30,7 @@ def test_diff_present(capsys: "CaptureFixture") -> None:
     with pytest.raises(SystemExit):
         main(["black", str(DIRTY_NOTEBOOK), "--nbqa-diff"])
     out, err = capsys.readouterr()
+    err = err.encode("ascii", "backslashreplace").decode()
     expected_out = f"""\x1b[1mCell 2\x1b[0m
 ------
 --- {str(DIRTY_NOTEBOOK)}
@@ -59,7 +61,18 @@ def test_diff_present(capsys: "CaptureFixture") -> None:
 To apply these changes use `--nbqa-mutate` instead of `--nbqa-diff`
 """
     assert out == expected_out
-    assert err == ""
+    expected_err = (
+        dedent(
+            f"""\
+            reformatted {str(DIRTY_NOTEBOOK)}
+            All done! {SPARKLES} {SHORTCAKE} {SPARKLES}
+            1 file reformatted.
+            """
+        )
+        .encode("ascii", "backslashreplace")
+        .decode()
+    )
+    assert err == expected_err
 
 
 def test_diff_and_mutate() -> None:

--- a/tests/tools/test_black.py
+++ b/tests/tools/test_black.py
@@ -297,6 +297,7 @@ def test_black_works_with_commented_magics(capsys: "CaptureFixture") -> None:
         main(["black", path, "--nbqa-diff"])
 
     out, err = capsys.readouterr()
+    err = err.encode("ascii", "backslashreplace").decode()
     expected_out = f"""\
 \x1b[1mCell 1\x1b[0m
 ------
@@ -309,7 +310,17 @@ def test_black_works_with_commented_magics(capsys: "CaptureFixture") -> None:
 \x1b[0m
 To apply these changes use `--nbqa-mutate` instead of `--nbqa-diff`
 """
-    expected_err = ""
+    expected_err = (
+        dedent(
+            f"""\
+            reformatted {path}
+            All done! {SPARKLES} {SHORTCAKE} {SPARKLES}
+            1 file reformatted.
+            """
+        )
+        .encode("ascii", "backslashreplace")
+        .decode()
+    )
     assert expected_out == out
     assert expected_err == err
 
@@ -329,6 +340,7 @@ def test_black_works_with_leading_comment(capsys: "CaptureFixture") -> None:
         main(["black", path, "--nbqa-diff"])
 
     out, err = capsys.readouterr()
+    err = err.encode("ascii", "backslashreplace").decode()
     expected_out = f"""\
 \x1b[1mCell 3\x1b[0m
 ------
@@ -342,7 +354,17 @@ def test_black_works_with_leading_comment(capsys: "CaptureFixture") -> None:
 
 To apply these changes use `--nbqa-mutate` instead of `--nbqa-diff`
 """
-    expected_err = ""
+    expected_err = (
+        dedent(
+            f"""\
+            reformatted {path}
+            All done! {SPARKLES} {SHORTCAKE} {SPARKLES}
+            1 file reformatted.
+            """
+        )
+        .encode("ascii", "backslashreplace")
+        .decode()
+    )
     assert expected_out == out
     assert expected_err == err
 

--- a/tests/tools/test_black.py
+++ b/tests/tools/test_black.py
@@ -381,3 +381,39 @@ def test_black_works_with_literal_assignment(capsys: "CaptureFixture") -> None:
 
     assert expected_out == out
     assert expected_err == err
+
+
+def test_invalid_syntax_with_nbqa_diff(capsys: "CaptureFixture") -> None:
+    """
+    Check that using nbqa-diff when there's invalid syntax doesn't have empty output.
+
+    Parameters
+    ----------
+    capsys
+        Pytest fixture to capture stdout and stderr.
+    """
+    path = os.path.abspath(
+        os.path.join("tests", "invalid_data", "assignment_to_literal.ipynb")
+    )
+
+    with pytest.raises(SystemExit):
+        main(["black", path, "--nbqa-diff"])
+
+    out, err = capsys.readouterr()
+    expected_out = ""
+    expected_err = (
+        (
+            f"error: cannot format {path}: "
+            "cannot use --safe with this file; failed to parse source file.  AST error message: "
+            "can't assign to literal (<unknown>, cell_1:1)\nOh no! "
+            f"{COLLISION} {BROKEN_HEART} {COLLISION}\n1 file failed to reformat.\n"
+        )
+        .encode("ascii", "backslashreplace")
+        .decode()
+    )
+    # This is required because linux supports emojis
+    # so both should have \\ for comparison
+    err = err.encode("ascii", "backslashreplace").decode()
+
+    assert expected_out == out
+    assert expected_err == err


### PR DESCRIPTION
closes #483 

Original stderr message is kept, but afterwards there's the nbqa message "to apply these changes, use --nbqa-mutate", so I think it's clear enough that the changes haven't been applied

e.g.
```
$ nbqa black tests/data/notebook_for_testing.ipynb --nbqa-diff
Cell 2
------
--- tests/data/notebook_for_testing.ipynb
+++ tests/data/notebook_for_testing.ipynb
@@ -12,8 +12,8 @@
     'hello goodbye'
     """
 
-    return 'hello {}'.format(name)
+    return "hello {}".format(name)
 
 
 !ls
-hello(3)   
+hello(3)

Cell 4
------
--- tests/data/notebook_for_testing.ipynb
+++ tests/data/notebook_for_testing.ipynb
@@ -1,4 +1,4 @@
 from random import randint
 
 if __debug__:
-    %time randint(5,10)
+    %time randint(5, 10)

reformatted tests/data/notebook_for_testing.ipynb
All done! ✨ 🍰 ✨
1 file reformatted.
To apply these changes use `--nbqa-mutate` instead of `--nbqa-diff`
```