### PR TITLE
Extend addopts rather than overwrite

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -26,6 +26,11 @@ or you can put the following in your :code:`pyproject.toml` file
         "--extend-ignore=E203"
     ]
 
+.. note::
+    If you specify extra flags via both the :code:`pyproject.toml` file and the command-line, both will be passed on to the underlying command-line tool,
+    with the options specified in :code:`pyproject.toml` passed first. In this case the exact behaviour will depend on the tool and the option in question.
+    It's common that subsequent flags override earlier ones, but check the documentation for the tool and option in question to be sure.
+
 Allow mutations
 ~~~~~~~~~~~~~~~
 

--- a/nbqa/__main__.py
+++ b/nbqa/__main__.py
@@ -325,8 +325,7 @@ def _get_configs(cli_args: CLIArgs, project_root: Path) -> Configs:
         if getattr(cli_args, section) is not None:
             if section == "addopts":
                 # addopts are added to / overridden rather than replaced outright
-                # Sequence[str] has no attribute extend. Should this be typed as List[str]?
-                config["addopts"].extend(getattr(cli_args, section))  # type: ignore
+                config["addopts"] = (*config["addopts"], *getattr(cli_args, section))
             else:
                 # TypedDict key must be a string literal
                 config[section] = getattr(cli_args, section)  # type: ignore

--- a/nbqa/__main__.py
+++ b/nbqa/__main__.py
@@ -323,8 +323,13 @@ def _get_configs(cli_args: CLIArgs, project_root: Path) -> Configs:
     # If a section was passed via CLI, use that.
     for section in config:
         if getattr(cli_args, section) is not None:
-            # TypedDict key must be a string literal
-            config[section] = getattr(cli_args, section)  # type: ignore
+            if section == "addopts":
+                # addopts are added to / overridden rather than replaced outright
+                # Sequence[str] has no attribute extend. Should this be typed as List[str]?
+                config["addopts"].extend(getattr(cli_args, section))  # type: ignore
+            else:
+                # TypedDict key must be a string literal
+                config[section] = getattr(cli_args, section)  # type: ignore
 
     # add default options
     if cli_args.command == "isort":

--- a/tests/test_pyproject_toml.py
+++ b/tests/test_pyproject_toml.py
@@ -72,12 +72,13 @@ def test_cli_extends_pyprojecttoml(capsys: "CaptureFixture") -> None:
 
     # if arguments are specified on command line, they will take precedence
     # over those specified in the pyproject.toml
+    notebook_path = os.path.join("tests", "data", "notebook_for_testing.ipynb")
     expected_out = dedent(
-        """\
-        tests/data/notebook_for_testing.ipynb:cell_1:1:1: F401 'os' imported but unused
-        tests/data/notebook_for_testing.ipynb:cell_1:3:1: F401 'glob' imported but unused
-        tests/data/notebook_for_testing.ipynb:cell_1:5:1: F401 'nbqa' imported but unused
-        tests/data/notebook_for_testing.ipynb:cell_4:1:1: F401 'random.randint' imported but unused
+        f"""\
+        {notebook_path}:cell_1:1:1: F401 'os' imported but unused
+        {notebook_path}:cell_1:3:1: F401 'glob' imported but unused
+        {notebook_path}:cell_1:5:1: F401 'nbqa' imported but unused
+        {notebook_path}:cell_4:1:1: F401 'random.randint' imported but unused
         """
     )
     assert out == expected_out

--- a/tests/test_pyproject_toml.py
+++ b/tests/test_pyproject_toml.py
@@ -40,7 +40,7 @@ def test_pyproject_toml_works(capsys: "CaptureFixture") -> None:
     assert out == expected_out
 
 
-def test_cli_overwrites_pyprojecttoml(capsys: "CaptureFixture") -> None:
+def test_cli_extends_pyprojecttoml(capsys: "CaptureFixture") -> None:
     """
     Check CLI args overwrite pyproject.toml
 
@@ -64,11 +64,20 @@ def test_cli_overwrites_pyprojecttoml(capsys: "CaptureFixture") -> None:
         [
             "flake8",
             os.path.join("tests", "data", "notebook_for_testing.ipynb"),
-            "--select=E303",
+            "--ignore=E402,W291",
         ]
     )
+    out, _ = capsys.readouterr()
     Path("pyproject.toml").unlink()
 
-    out, _ = capsys.readouterr()
-    expected_out = ""
+    # if arguments are specified on command line, they will take precedence
+    # over those specified in the pyproject.toml
+    expected_out = dedent(
+        """\
+        tests/data/notebook_for_testing.ipynb:cell_1:1:1: F401 'os' imported but unused
+        tests/data/notebook_for_testing.ipynb:cell_1:3:1: F401 'glob' imported but unused
+        tests/data/notebook_for_testing.ipynb:cell_1:5:1: F401 'nbqa' imported but unused
+        tests/data/notebook_for_testing.ipynb:cell_4:1:1: F401 'random.randint' imported but unused
+        """
+    )
     assert out == expected_out


### PR DESCRIPTION
This PR allows addopts to be extended with command line arguments rather than overridden, fixing #626 

I added a simple test, actually it modifies an existing test that seemed to be checking for the overwrite behaviour. Let me know if you'd rather have a new test and whether I chose an appropriate location for the test.