### PR TITLE
Remove unnecessary disables from pylint config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,4 @@ disable = [
   "W1510", # I need to run subprocess.run without check because it's OK if it fails
   "E0401", # Unable to import '_pytest.capture' (this is just for typing anyway)
   "E0611", # No name 'TypedDict' in module 'typing'
-  "E1136", # Value 'Optional' is unsubscriptable (bug? https://github.com/PyCQA/pylint/issues/3882)
-  "E0239", # Inheriting 'NamedTuple', which is not a class. (bug? https://github.com/PyCQA/pylint/issues/2570)
 ]


### PR DESCRIPTION
This repository popped up in my explore tab and while looking at the `pyproject` I noticed these two comments and disables which mention issues that have been fixed in the latest versions of `pylint`.
I didn't see a pin for `pylint` in the `setup.cfg` so I guess you're using the latest version for your CI and thought I would remove them.

Feel free to close this if this is unwanted!