### PR TITLE
skip if all magics

### DIFF
--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,4 +1,4 @@
-myst-parser>=0.12.0
+myst-parser==0.16.1  # todo: unpin
 Sphinx>=3.2.0
 sphinx-copybutton>=0.3.0
 sphinx-rtd-theme>=0.5.0

--- a/nbqa/save_code_source.py
+++ b/nbqa/save_code_source.py
@@ -280,7 +280,9 @@ def _should_ignore_code_cell(
     ):
         return True
     if all(
-        any(line.startswith(symbol) for symbol in ("%", "?", "!")) for line in source
+        any(line.startswith(symbol) for symbol in ("%", "?", "!"))
+        for line in source
+        if line.strip()
     ):
         # It's all magic, nothing to process
         return True

--- a/nbqa/save_code_source.py
+++ b/nbqa/save_code_source.py
@@ -279,6 +279,11 @@ def _should_ignore_code_cell(
         or any(magic in joined_source for magic in TRANSFORMED_MAGICS)
     ):
         return True
+    if all(
+        any(line.startswith(symbol) for symbol in ("%", "?", "!")) for line in source
+    ):
+        # It's all magic, nothing to process
+        return True
     try:
         ast.parse(joined_source)
     except SyntaxError:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 autoflake
 autopep8
-black
+black==21.12b0  # todo: unpin
 blacken-docs
 coverage[toml]
 flake8

--- a/tests/data/all_magic_cell.ipynb
+++ b/tests/data/all_magic_cell.ipynb
@@ -11,7 +11,8 @@
    "outputs": [],
    "source": [
     "%load_ext nb_black\n",
-    "%matplotlib inline"
+    "\n",
+    "%matplotlib inline\n"
    ]
   },
   {

--- a/tests/data/all_magic_cell.ipynb
+++ b/tests/data/all_magic_cell.ipynb
@@ -1,0 +1,52 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "skip-flake8"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "%load_ext nb_black\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "\n",
+    "\n",
+    "sys.version"
+   ]
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/tests/tools/test_flake8_works.py
+++ b/tests/tools/test_flake8_works.py
@@ -75,3 +75,20 @@ def test_flake8_works(
     expected_err = ""
     assert sorted(out.splitlines()) == sorted(expected_out.splitlines())
     assert sorted(err.splitlines()) == sorted(expected_err.splitlines())
+
+
+def test_cell_with_all_magics(capsys: "CaptureFixture") -> None:
+    """
+    Should ignore cell with all magics.
+
+    Parameters
+    ----------
+    capsys
+        Pytest fixture to capture stdout and stderr.
+    """
+    path = os.path.join("tests", "data", "all_magic_cell.ipynb")
+    main(["flake8", path])
+
+    out, err = capsys.readouterr()
+    assert out == ""
+    assert err == ""


### PR DESCRIPTION
closes #700 

The idea is that if every line in a cell starts with a `%`, `!`, or `?`, then we can just ignore the cell completely, as it's all magic and there's nothing to process

Any edge cases I might be missing? cc @nbQA-dev/nbqa-core @LauraRichter