### PR TITLE
Update Black version to 22.3.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     hooks:
       - id: validate_manifest
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/mirrors-prettier


### PR DESCRIPTION
This change updates the precommit config to have the latest Black
version (at the time of this commit). The main reason for doing so is to
get the latest fixes for a bug caused in a dependency library, click.
More details about this can be found at
https://github.com/psf/black/issues/2964

This resolves #716 