### PR TITLE
Fix documentation to enable isort with 'black' profile

### DIFF
--- a/docs/pre-commit.rst
+++ b/docs/pre-commit.rst
@@ -60,7 +60,7 @@ To pass command line arguments, use the `pre-commit args <https://pre-commit.com
        - id: nbqa-pyupgrade
          args: [--py38-plus]
        - id: nbqa-isort
-         args: [--profile, black]
+         args: [--profile=black] 
        - id: nbqa-flake8
          args: [--ignore=E402] # E402 module level import not at top of file
 

--- a/docs/pre-commit.rst
+++ b/docs/pre-commit.rst
@@ -60,7 +60,7 @@ To pass command line arguments, use the `pre-commit args <https://pre-commit.com
        - id: nbqa-pyupgrade
          args: [--py38-plus]
        - id: nbqa-isort
-         args: [--profile=black] 
+         args: [--profile=black]
        - id: nbqa-flake8
          args: [--ignore=E402] # E402 module level import not at top of file
 


### PR DESCRIPTION
nbqa-isort throws an error when adding as pre-commit when args are not concatenanated