### PR TITLE
Update messages in tests/tools/test_pylint_works.py

### DIFF
--- a/tests/tools/test_pylint_works.py
+++ b/tests/tools/test_pylint_works.py
@@ -34,15 +34,15 @@ def test_pylint_works(capsys: "CaptureFixture") -> None:
         f'{notebook1}:cell_4:1:0: C0413: Import "from random import randint" should be placed at the top of the module (wrong-import-position)\n'  # noqa: E501
         f'{notebook1}:cell_5:1:0: C0413: Import "import pprint" should be placed at the top of the module (wrong-import-position)\n'  # noqa: E501
         f'{notebook1}:cell_5:2:0: C0413: Import "import sys" should be placed at the top of the module (wrong-import-position)\n'  # noqa: E501
-        f'{notebook1}:cell_4:1:0: C0411: standard import "from random import randint" should be placed before "import nbqa" (wrong-import-order)\n'  # noqa: E501
-        f'{notebook1}:cell_5:1:0: C0411: standard import "import pprint" should be placed before "import nbqa" (wrong-import-order)\n'  # noqa: E501
-        f'{notebook1}:cell_5:2:0: C0411: standard import "import sys" should be placed before "import nbqa" (wrong-import-order)\n'  # noqa: E501
+        f'{notebook1}:cell_4:1:0: C0411: standard import "random.randint" should be placed before first party import "nbqa"  (wrong-import-order)\n'  # noqa: E501
+        f'{notebook1}:cell_5:1:0: C0411: standard import "pprint" should be placed before first party import "nbqa"  (wrong-import-order)\n'  # noqa: E501
+        f'{notebook1}:cell_5:2:0: C0411: standard import "sys" should be placed before first party import "nbqa"  (wrong-import-order)\n'  # noqa: E501
         f"{notebook1}:cell_1:1:0: W0611: Unused import os (unused-import)\n"
         f"{notebook1}:cell_1:3:0: W0611: Unused import glob (unused-import)\n"
         f"{notebook1}:cell_1:5:0: W0611: Unused import nbqa (unused-import)\n"
         f"{notebook1}:cell_4:1:0: W0611: Unused randint imported from random (unused-import)\n"
         "************* Module tests.data.notebook_with_indented_magics\n"
-        f'{notebook2}:cell_3:3:0: C0411: standard import "import operator" should be placed before "from IPython import get_ipython" (wrong-import-order)\n'  # noqa: E501
+        f'{notebook2}:cell_3:3:0: C0411: standard import "operator" should be placed before third party import "IPython.get_ipython" (wrong-import-order)\n'  # noqa: E501
         f"{notebook2}:cell_1:1:0: W0611: Unused randint imported from random (unused-import)\n"
         f"{notebook2}:cell_1:2:0: W0611: Unused get_ipython imported from IPython (unused-import)\n"
         "\n"


### PR DESCRIPTION
Pylint 3.1.0 updated the messages of the wrong-import-order check:
https://github.com/pylint-dev/pylint/releases/tag/v3.1.0

This commit updates the messages in the test accordingly so the test passes again.

Closes #838 