### PR TITLE
Fixed deprecation of ruff <path>

### DIFF
--- a/nbqa/__main__.py
+++ b/nbqa/__main__.py
@@ -359,6 +359,9 @@ def _run_command(  # pylint: disable=too-many-locals
     if main_command == "mypy" and "MYPY_FORCE_COLOR" not in my_env:
         my_env["MYPY_FORCE_COLOR"] = "1"
 
+    if main_command == "ruff":
+        sub_commands.insert(0, "check")
+
     if shell:
         # We already checked that which does not return None
 


### PR DESCRIPTION
Ruff 0.3.0 deprecated the usage of ruff <path> in favor of ruff check <path>:
https://github.com/astral-sh/ruff/releases/tag/v0.3.0

This commit fixes this with making nbqa ruff call ruff check instead of ruff.
Closes #837 