### PR TITLE
add nbqa_ipynb to temporary files

### DIFF
--- a/docs/known-limitations.rst
+++ b/docs/known-limitations.rst
@@ -11,7 +11,19 @@ then the following will still not be processed:
 - cells with code which ``IPython`` would transform magics into (e.g. ``get_ipython().system('ls')``).
 
 Because ``nbQA`` converts the code cells in Jupyter notebooks to temporary Python files for linting, certain flags like ``flake8``'s
-``--per-file-ignores`` don't work. The temporary Python files will not match the specified file patterns and ignored error codes will still
+``--per-file-ignores`` don't work perfectly.
+The temporary Python files will not match the specified file patterns and ignored error codes will still
 surface (`GH issue <https://github.com/nbQA-dev/nbQA/issues/730>`_).
+nbqa-generated temporary files will contain the string ``nbqa_ipynb``,
+so you can still apply per-file-ignores if you add an additional pattern:
+
+.. sourcecode:: ini
+
+    [flake8]
+    per-file-ignores =
+      examples/*.ipynb: E402
+      examples/*nbqa_ipynb.py: E402
+
+The directory and the stem of the filename are preserved, so e.g. ``path/to/mynotebook.ipynb`` will be ``path/to/mynotebook{randomstring}_nbqa_ipynb.py`` when nbqa passes it to the linter.
 
 Any other limitation is likely unintentional - if you run into any, please do report an issue.

--- a/nbqa/__main__.py
+++ b/nbqa/__main__.py
@@ -526,7 +526,7 @@ def _get_nb_to_tmp_mapping(
                 prefix=remove_suffix(
                     os.path.basename(notebook), os.path.splitext(notebook)[-1]
                 ),
-                suffix=SUFFIX[md],
+                suffix="_nbqa_ipynb" + SUFFIX[md],
             )
         )
         relative_path, _ = get_relative_and_absolute_paths(


### PR DESCRIPTION
allows config globs to apply to nbqa-generated files.

Added to suffix, so e.g. all generated .py files match `*nbqa_ipynb.py` e.g. `default_magicgr4dg5bw_nbqa_ipynb.py`

docs and tests updated as best I could find.

closes #789