### PR TITLE
Add MegaLinter to the used-by list

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ add them to [`additional_dependencies`](http://pre-commit.com/#pre-commit-config
 - https://github.com/mayou36/raredecay
 - https://github.com/neomatrix369/nlp_profiler
 - https://github.com/openforcefield/openff-system
+- https://github.com/oxsecurity/megalinter
 - https://github.com/pandas-profiling/pandas-profiling
 - https://github.com/paw-lu/dotfiles
 - https://github.com/pawamoy/wps-light
@@ -219,6 +220,8 @@ add them to [`additional_dependencies`](http://pre-commit.com/#pre-commit-config
 - https://github.com/zfit/zfit-tutorials
 
 </details>
+
+nbQA is also built into [MegaLinter](https://megalinter.io/latest/descriptors/python_nbqa/), so if you run MegaLinter in your CI, your notebooks are already covered.
 
 Is your project missing? Let us know, or open a pull request!
 

--- a/README.md
+++ b/README.md
@@ -221,8 +221,6 @@ add them to [`additional_dependencies`](http://pre-commit.com/#pre-commit-config
 
 </details>
 
-nbQA is also built into [MegaLinter](https://megalinter.io/latest/descriptors/python_nbqa/), so if you run MegaLinter in your CI, your notebooks are already covered.
-
 Is your project missing? Let us know, or open a pull request!
 
 ## 💬 Testimonials


### PR DESCRIPTION
Hi! MegaLinter (https://megalinter.io) ships nbQA as one of its built-in Python linters, so notebooks get checked out of the box for its users: https://megalinter.io/latest/descriptors/python_nbqa/

The README says to open a PR if a project is missing, so here it is :) Added the repo to the list and a one-liner below it. Feel free to tweak or trim the wording.

Thanks for maintaining nbQA!