### PR TITLE
Report the first line of a cell as line 1, not line 0

### DIFF
--- a/nbqa/save_code_source.py
+++ b/nbqa/save_code_source.py
@@ -234,14 +234,18 @@ def _get_line_numbers_for_mapping(
     lines_in_cell = cell_source.splitlines()
     line_mapping: MutableMapping[int, int] = {}
 
+    # Line 0 of the parsed cell is the CODE_SEPARATOR which nbQA itself
+    # inserted, so a diagnostic reported there belongs to the first line the
+    # user actually wrote. Cell lines are 1-indexed, and cell_N:0 does not
+    # exist - see https://github.com/nbQA-dev/nbQA/issues/821
     if not magic_substitutions:
-        line_mapping.update({i: i for i in range(len(lines_in_cell))})
+        line_mapping.update({i: max(i, 1) for i in range(len(lines_in_cell))})
     else:
         line_number = -1
 
         for line_no, _ in enumerate(lines_in_cell):
             line_number += 1
-            line_mapping[line_no] = line_number
+            line_mapping[line_no] = max(line_number, 1)
 
     return line_mapping
 

--- a/tests/test_jupytext.py
+++ b/tests/test_jupytext.py
@@ -296,11 +296,11 @@ def test_jupytext_on_folder(capsys: "CaptureFixture") -> None:
     )
     out, _ = capsys.readouterr()
     expected = (
-        f'{os.path.join(path, "invalid_syntax.ipynb")}:cell_1:0 at module level:\n'
+        f'{os.path.join(path, "invalid_syntax.ipynb")}:cell_1:1 at module level:\n'
         "        D100: Missing docstring in public module\n"
-        f'{os.path.join(path, "assignment_to_literal.ipynb")}:cell_1:0 at module level:\n'
+        f'{os.path.join(path, "assignment_to_literal.ipynb")}:cell_1:1 at module level:\n'
         "        D100: Missing docstring in public module\n"
-        f'{os.path.join(path, "automagic.ipynb")}:cell_1:0 at module level:\n'
+        f'{os.path.join(path, "automagic.ipynb")}:cell_1:1 at module level:\n'
         "        D100: Missing docstring in public module\n"
     )
     assert "\n".join(sorted(out.splitlines())) == "\n".join(

--- a/tests/test_map_python_line_to_nb_lines.py
+++ b/tests/test_map_python_line_to_nb_lines.py
@@ -1,8 +1,15 @@
 """Check output from third-party tool is correctly parsed."""
 
+import os
 from textwrap import dedent
+from typing import TYPE_CHECKING
 
+from nbqa.__main__ import main
 from nbqa.output_parser import map_python_line_to_nb_lines
+from nbqa.save_code_source import _get_line_numbers_for_mapping
+
+if TYPE_CHECKING:
+    from _pytest.capture import CaptureFixture
 
 
 def test_map_python_line_to_nb_lines() -> None:
@@ -33,3 +40,21 @@ def test_black_unparseable_output() -> None:
         1 file failed to reformat.
         """)
     assert result == expected
+
+
+def test_separator_line_maps_to_first_line_of_cell() -> None:
+    """The line nbQA inserts itself must not map to cell line 0."""
+    parsed_cell = "# %%NBQA-CELL-SEPabc123\nimport math\nimport random\n"
+    mapping = _get_line_numbers_for_mapping(parsed_cell, [])
+    assert mapping == {0: 1, 1: 1, 2: 2}
+
+
+def test_module_level_diagnostic_is_reported_at_line_one(
+    capsys: "CaptureFixture",
+) -> None:
+    """A message about the whole module must point at the first line of cell 1."""
+    notebook = os.path.join("tests", "data", "simple_imports.ipynb")
+    main(["pylint", notebook, "--disable=all", "--enable=C0114"])
+    out, _ = capsys.readouterr()
+    assert "cell_1:0:" not in out
+    assert f"{notebook}:cell_1:1:0: C0114" in out

--- a/tests/tools/test_pydocstyle.py
+++ b/tests/tools/test_pydocstyle.py
@@ -24,7 +24,7 @@ def test_pydocstyle_works(capsys: "CaptureFixture") -> None:
     # check out and err
     out, err = capsys.readouterr()
     expected_out = (
-        f"{path}:cell_1:0 at module level:\n"
+        f"{path}:cell_1:1 at module level:\n"
         "        D100: Missing docstring in public module\n"
         f"{path}:cell_2:3 in public function `hello`:\n"
         "        D202: No blank lines allowed after function docstring (found 1)\n"


### PR DESCRIPTION
Closes #821.

A diagnostic about the module as a whole comes back pointing at a line that does not exist:

```console
$ ruff check --isolated --select D100,F401 t.py
t.py:1:1: D100 Missing docstring in public module
t.py:1:8: F401 [*] `math` imported but unused
t.py:2:8: F401 [*] `random` imported but unused

$ nbqa --nbqa-shell ruff t.ipynb --isolated --select D100,F401
t.ipynb:cell_1:0:1: D100 Missing docstring in public module
t.ipynb:cell_1:1:8: F401 [*] `math` imported but unused
t.ipynb:cell_1:2:8: F401 [*] `random` imported but unused
```

`F401` is 1-indexed and `D100` is 0-indexed, in the same output. `flake8` behaves the same way. On the equivalent plain `.py` file both are at line 1, so the 0 does not come from the tool.

### Cause

Every cell in the temporary Python file starts with the `# %%NBQA-CELL-SEP...` comment nbQA inserts itself, and `_get_line_numbers_for_mapping` maps that line to cell line `0`. A module-level message is reported by the tool on line 1 of the file -- that is, on the separator -- so it is mapped back to `cell_1:0`.

This maps the separator line to the first line the user actually wrote.

### Existing expectations

Four `pydocstyle` expectations recorded `cell_1:0 at module level` -- one in `tests/tools/test_pydocstyle.py` and three in `tests/test_jupytext.py`. They froze exactly the behaviour this issue is about, so they are updated to `cell_1:1` in the same commit. Flagging it explicitly rather than burying it in the diff: if you would rather keep the old numbering, this PR is the wrong change and I will close it.

### Tests

In `tests/test_map_python_line_to_nb_lines.py`: a unit test on `_get_line_numbers_for_mapping` and an end-to-end check through `pylint --disable=all --enable=C0114`. Both fail on `main`.

### Test suite

`3 failed, 118 passed, 3 skipped` on this branch. The same three `tests/tools/test_ruff_works.py` failures are present on `main` (newer `ruff` output format) and are unrelated to this change.
