### PR TITLE
Preserve the tool's exit code when the notebook is unchanged

### DIFF
--- a/nbqa/__main__.py
+++ b/nbqa/__main__.py
@@ -791,8 +791,14 @@ def _main(cli_args: CLIArgs, configs: Configs) -> int:
         sys.stderr.write(output.err)
 
         if mutated and not actually_mutated:
-            output_code = 0
             mutated = False
+            if not output.out.strip() and not output.err.strip():
+                # The tool rewrote the temporary Python file, the notebook came
+                # back unchanged, and the tool reported nothing: its non-zero
+                # exit code was about having modified files, so there is
+                # nothing left to report. If it did print something, keep its
+                # exit code - see https://github.com/nbQA-dev/nbQA/issues/872
+                output_code = 0
 
         if saved_sources.failed_notebooks:
             output_code = 123

--- a/tests/test_return_code.py
+++ b/tests/test_return_code.py
@@ -4,6 +4,10 @@ import subprocess
 from functools import partial
 from pathlib import Path
 from typing import Sequence
+from unittest import mock
+
+from nbqa import __main__ as nbqa_main
+from nbqa.output_parser import Output
 
 TESTS_DIR = Path("tests")
 TEST_DATA_DIR = TESTS_DIR / "data"
@@ -15,6 +19,7 @@ INVALID_SYNTAX_NOTEBOOK = TESTS_DIR / "invalid_data" / "invalid_syntax.ipynb"
 # Interpret the below constants in the same context as that of pre-commit tool
 # Success indicates the QA tool reported no issues.
 PASSED = 0
+FAILED = 1
 
 
 def _run_nbqa_with(command: str, notebooks: Sequence[Path], *args: str) -> int:
@@ -83,3 +88,41 @@ def test_check_ast_return_code() -> None:
         check_ast_runner([INVALID_SYNTAX_NOTEBOOK], "--nbqa-dont-skip-bad-cells")
         != PASSED
     )
+
+
+def test_return_code_survives_unchanged_notebook() -> None:
+    """Tool reported an issue, so nbQA must not report success.
+
+    See https://github.com/nbQA-dev/nbQA/issues/872: ``ruff check --fix`` fixes
+    some violations, leaves others, and exits 1. If nbQA's round-trip happens to
+    leave the notebook unchanged, that 1 must still reach the caller.
+    """
+    reported = Output("clean_notebook.ipynb:cell_1:1:1: F821 Undefined name `x`\n", "")
+    with mock.patch.object(
+        nbqa_main, "_run_command", return_value=(reported, FAILED, True)
+    ), mock.patch.object(
+        nbqa_main, "_post_process_notebooks", return_value=(False, reported)
+    ):
+        assert nbqa_main.main(["flake8", str(CLEAN_NOTEBOOK)]) == FAILED
+
+
+def test_silent_tool_exit_code_is_still_reset() -> None:
+    """Tool said nothing, so its exit code was only about rewriting files."""
+    silent = Output("", "")
+    with mock.patch.object(
+        nbqa_main, "_run_command", return_value=(silent, FAILED, True)
+    ), mock.patch.object(
+        nbqa_main, "_post_process_notebooks", return_value=(False, silent)
+    ):
+        assert nbqa_main.main(["flake8", str(CLEAN_NOTEBOOK)]) == PASSED
+
+
+def test_success_stays_success_for_unchanged_notebook() -> None:
+    """``black`` reformatted the temporary file but the notebook is unchanged."""
+    reformatted = Output("", "reformatted clean_notebook.ipynb\n")
+    with mock.patch.object(
+        nbqa_main, "_run_command", return_value=(reformatted, PASSED, True)
+    ), mock.patch.object(
+        nbqa_main, "_post_process_notebooks", return_value=(False, reformatted)
+    ):
+        assert nbqa_main.main(["black", str(CLEAN_NOTEBOOK)]) == PASSED


### PR DESCRIPTION
Closes #872.

nbQA resets `output_code` to `0` whenever the third-party tool rewrote the temporary Python file but the round-trip back into the notebook produced no change:

```python
if mutated and not actually_mutated:
    output_code = 0
    mutated = False
```

That branch is there so a formatter which only touched the temporary file is not reported as having changed the notebook. It also swallows real failures, though: `ruff check --fix` can fix some violations, leave others unfixable and exit `1`, and nbQA still reports success -- so a pre-commit hook goes green over genuine errors.

This keeps the `mutated = False` reset and only zeroes the exit code when the tool printed nothing at all. If the tool printed something, there is something left to report, so its exit code survives.

I also tried simply dropping the `output_code = 0` reset. That breaks tools whose non-zero exit code *means* "I modified files" -- `blacken-docs`, which is in this repo's own `requirements-dev.txt`, is one of them -- so nbQA would start failing on a notebook it had successfully left unchanged. Hence the narrower condition.

### Tests

Three tests in `tests/test_return_code.py`, covering both directions of the new condition:

- tool exits 1 and prints a violation, notebook unchanged -> nbQA exits 1 (fails on `main` with `assert 0 == 1`)
- tool exits 1 and prints nothing, notebook unchanged -> nbQA exits 0 (the case the branch was written for)
- tool exits 0 after reformatting the temporary file -> nbQA exits 0

They use `unittest.mock` rather than a notebook fixture on purpose: I could not find an input where a real tool leaves the notebook unchanged *and* exits non-zero. The condition is reachable, but hard to hit from the outside -- which is probably why it had no coverage.

### Test suite

`3 failed, 119 passed, 3 skipped` on this branch. The three failures are present on `main` as well (`tests/tools/test_ruff_works.py` -- a newer `ruff` prints diagnostics in a different format) and are untouched by this change.
